### PR TITLE
feat(tabela): faixas de vencimento, cor por categoria e gestao de categorias

### DIFF
--- a/drizzle/0002_categorias_e_chat.sql
+++ b/drizzle/0002_categorias_e_chat.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "chat_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"context_id" uuid NOT NULL,
+	"role" text NOT NULL,
+	"content" text NOT NULL,
+	"payload" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "categories" ADD COLUMN "color_dark" text;--> statement-breakpoint
+ALTER TABLE "categories" ADD COLUMN "sort_order" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "categories" ADD COLUMN "archived_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "password_hash" text;--> statement-breakpoint
+ALTER TABLE "chat_messages" ADD CONSTRAINT "chat_messages_context_id_contexts_id_fk" FOREIGN KEY ("context_id") REFERENCES "public"."contexts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "chat_messages_context_created_idx" ON "chat_messages" USING btree ("context_id","created_at");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2424 @@
+{
+  "id": "5d55ad58-11b1-4be9-a7e3-6bb44bca39da",
+  "prevId": "1e70a243-95a8-41fb-bb18-946c8a546d78",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "account_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statement_close_day": {
+          "name": "statement_close_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_due_day": {
+          "name": "statement_due_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_context_idx": {
+          "name": "accounts_context_idx",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_context_id_contexts_id_fk": {
+          "name": "accounts_context_id_contexts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts_auth": {
+      "name": "accounts_auth",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_auth_user_id_users_id_fk": {
+          "name": "accounts_auth_user_id_users_id_fk",
+          "tableFrom": "accounts_auth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_auth_provider_provider_account_id_pk": {
+          "name": "accounts_auth_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_plan_checkins": {
+      "name": "action_plan_checkins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_cents": {
+          "name": "expected_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actual_cents": {
+          "name": "actual_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "action_plan_checkins_plan_id_action_plans_id_fk": {
+          "name": "action_plan_checkins_plan_id_action_plans_id_fk",
+          "tableFrom": "action_plan_checkins",
+          "tableTo": "action_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_plan_items": {
+      "name": "action_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saving_cents": {
+          "name": "saving_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pain": {
+          "name": "pain",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "action_plan_items_plan_id_action_plans_id_fk": {
+          "name": "action_plan_items_plan_id_action_plans_id_fk",
+          "tableFrom": "action_plan_items",
+          "tableTo": "action_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "action_plan_items_rule_id_recurrence_rules_id_fk": {
+          "name": "action_plan_items_rule_id_recurrence_rules_id_fk",
+          "tableFrom": "action_plan_items",
+          "tableTo": "recurrence_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_plans": {
+      "name": "action_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_cents": {
+          "name": "target_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "action_plans_context_id_contexts_id_fk": {
+          "name": "action_plans_context_id_contexts_id_fk",
+          "tableFrom": "action_plans",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aliases": {
+      "name": "aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hits": {
+          "name": "hits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "aliases_surface_target_key": {
+          "name": "aliases_surface_target_key",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_statements": {
+      "name": "card_statements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "card_statements_account_period_key": {
+          "name": "card_statements_account_period_key",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "card_statements_account_id_accounts_id_fk": {
+          "name": "card_statements_account_id_accounts_id_fk",
+          "tableFrom": "card_statements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_dark": {
+          "name": "color_dark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_key": {
+          "name": "categories_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_messages_context_created_idx": {
+          "name": "chat_messages_context_created_idx",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_context_id_contexts_id_fk": {
+          "name": "chat_messages_context_id_contexts_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contexts": {
+      "name": "contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contexts_slug_unique": {
+          "name": "contexts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extractions": {
+      "name": "extractions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidates": {
+          "name": "candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_transaction_id": {
+          "name": "resolved_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_action": {
+          "name": "user_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_diff": {
+          "name": "user_diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extractions_resolved_transaction_id_transactions_id_fk": {
+          "name": "extractions_resolved_transaction_id_transactions_id_fk",
+          "tableFrom": "extractions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "resolved_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fx_rates": {
+      "name": "fx_rates",
+      "schema": "",
+      "columns": {
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fx_rates_currency_day_pk": {
+          "name": "fx_rates_currency_day_pk",
+          "columns": [
+            "currency",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pct_of_income": {
+          "name": "pct_of_income",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "goals_ctx_cat_from_key": {
+          "name": "goals_ctx_cat_from_key",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_context_id_contexts_id_fk": {
+          "name": "goals_context_id_contexts_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "goals_category_id_categories_id_fk": {
+          "name": "goals_category_id_categories_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imported_transactions": {
+      "name": "imported_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dedup_hash": {
+          "name": "dedup_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matched_transaction_id": {
+          "name": "matched_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imported_transactions_dedup_key": {
+          "name": "imported_transactions_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imported_transactions_import_id_imports_id_fk": {
+          "name": "imported_transactions_import_id_imports_id_fk",
+          "tableFrom": "imported_transactions",
+          "tableTo": "imports",
+          "columnsFrom": [
+            "import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "imported_transactions_matched_transaction_id_transactions_id_fk": {
+          "name": "imported_transactions_matched_transaction_id_transactions_id_fk",
+          "tableFrom": "imported_transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "matched_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imports": {
+      "name": "imports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_label": {
+          "name": "period_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights": {
+      "name": "insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "insight_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "detected_for": {
+          "name": "detected_for",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "insights_fingerprint_key": {
+          "name": "insights_fingerprint_key",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insights_status_idx": {
+          "name": "insights_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detected_for",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insights_context_id_contexts_id_fk": {
+          "name": "insights_context_id_contexts_id_fk",
+          "tableFrom": "insights",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurrence_occurrences": {
+      "name": "recurrence_occurrences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_cents": {
+          "name": "expected_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fx_rate": {
+          "name": "fx_rate",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installment_no": {
+          "name": "installment_no",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_at": {
+          "name": "skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurrence_occurrences_rule_due_key": {
+          "name": "recurrence_occurrences_rule_due_key",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurrence_occurrences_open_idx": {
+          "name": "recurrence_occurrences_open_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recurrence_occurrences\".\"transaction_id\" is null and \"recurrence_occurrences\".\"skipped_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurrence_occurrences_rule_id_recurrence_rules_id_fk": {
+          "name": "recurrence_occurrences_rule_id_recurrence_rules_id_fk",
+          "tableFrom": "recurrence_occurrences",
+          "tableTo": "recurrence_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurrence_rules": {
+      "name": "recurrence_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "tx_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_expression": {
+          "name": "amount_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_inputs": {
+          "name": "amount_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "cadence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installment_current": {
+          "name": "installment_current",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installment_total": {
+          "name": "installment_total",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installment_anchor": {
+          "name": "installment_anchor",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fx_currency": {
+          "name": "fx_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fx_amount": {
+          "name": "fx_amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_on": {
+          "name": "ends_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recurrence_rules_context_idx": {
+          "name": "recurrence_rules_context_idx",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recurrence_rules_active_idx": {
+          "name": "recurrence_rules_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurrence_rules_context_id_contexts_id_fk": {
+          "name": "recurrence_rules_context_id_contexts_id_fk",
+          "tableFrom": "recurrence_rules",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recurrence_rules_category_id_categories_id_fk": {
+          "name": "recurrence_rules_category_id_categories_id_fk",
+          "tableFrom": "recurrence_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recurrence_rules_account_id_accounts_id_fk": {
+          "name": "recurrence_rules_account_id_accounts_id_fk",
+          "tableFrom": "recurrence_rules",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_splits": {
+      "name": "transaction_splits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transaction_splits_tx_idx": {
+          "name": "transaction_splits_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_splits_transaction_id_transactions_id_fk": {
+          "name": "transaction_splits_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_splits",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_splits_context_id_contexts_id_fk": {
+          "name": "transaction_splits_context_id_contexts_id_fk",
+          "tableFrom": "transaction_splits",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transaction_splits_category_id_categories_id_fk": {
+          "name": "transaction_splits_category_id_categories_id_fk",
+          "tableFrom": "transaction_splits",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "tx_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_expression": {
+          "name": "amount_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_inputs": {
+          "name": "amount_inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counterparty_account_id": {
+          "name": "counterparty_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_id": {
+          "name": "statement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurrence_id": {
+          "name": "occurrence_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "entry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_id": {
+          "name": "extraction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_context_due_idx": {
+          "name": "transactions_context_due_idx",
+          "columns": [
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_category_due_idx": {
+          "name": "transactions_category_due_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_account_due_idx": {
+          "name": "transactions_account_due_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_statement_idx": {
+          "name": "transactions_statement_idx",
+          "columns": [
+            {
+              "expression": "statement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_rule_due_idx": {
+          "name": "transactions_rule_due_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_context_id_contexts_id_fk": {
+          "name": "transactions_context_id_contexts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_category_id_categories_id_fk": {
+          "name": "transactions_category_id_categories_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_counterparty_account_id_accounts_id_fk": {
+          "name": "transactions_counterparty_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "counterparty_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_statement_id_card_statements_id_fk": {
+          "name": "transactions_statement_id_card_statements_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "card_statements",
+          "columnsFrom": [
+            "statement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_rule_id_recurrence_rules_id_fk": {
+          "name": "transactions_rule_id_recurrence_rules_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurrence_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_occurrence_id_recurrence_occurrences_id_fk": {
+          "name": "transactions_occurrence_id_recurrence_occurrences_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "recurrence_occurrences",
+          "columnsFrom": [
+            "occurrence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contexts": {
+      "name": "user_contexts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_contexts_user_id_users_id_fk": {
+          "name": "user_contexts_user_id_users_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_contexts_context_id_contexts_id_fk": {
+          "name": "user_contexts_context_id_contexts_id_fk",
+          "tableFrom": "user_contexts",
+          "tableTo": "contexts",
+          "columnsFrom": [
+            "context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_contexts_user_id_context_id_pk": {
+          "name": "user_contexts_user_id_context_id_pk",
+          "columns": [
+            "user_id",
+            "context_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_kind": {
+      "name": "account_kind",
+      "schema": "public",
+      "values": [
+        "checking",
+        "credit_card",
+        "cash",
+        "investment"
+      ]
+    },
+    "public.cadence": {
+      "name": "cadence",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "weekly",
+        "biweekly",
+        "yearly",
+        "one_off"
+      ]
+    },
+    "public.entry_source": {
+      "name": "entry_source",
+      "schema": "public",
+      "values": [
+        "nl",
+        "manual",
+        "import",
+        "recurrence"
+      ]
+    },
+    "public.insight_status": {
+      "name": "insight_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "done",
+        "abandoned"
+      ]
+    },
+    "public.tx_kind": {
+      "name": "tx_kind",
+      "schema": "public",
+      "values": [
+        "expense",
+        "income",
+        "transfer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784129408469,
       "tag": "0000_dapper_freak",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786031172058,
+      "tag": "0002_categorias_e_chat",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { and, eq, isNull, ne, sql } from 'drizzle-orm'
+import { auth } from '@/auth'
+import { db } from '@/db'
+import { categories, transactions } from '@/db/schema'
+import { slotByKey } from '@/lib/categories/palette'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const PatchSchema = z.object({
+  name: z.string().min(1).max(40).optional(),
+  colorKey: z.string().max(20).optional(),
+})
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 })
+
+  const { id } = await ctx.params
+
+  let parsed
+  try {
+    parsed = PatchSchema.safeParse(await req.json())
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido' }, { status: 400 })
+  }
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Dados inválidos' }, { status: 400 })
+  }
+
+  const [cat] = await db.select().from(categories).where(eq(categories.id, id)).limit(1)
+  if (!cat) return NextResponse.json({ error: 'Categoria não encontrada' }, { status: 404 })
+
+  const patch: { name?: string; color?: string; colorDark?: string | null } = {}
+
+  if (parsed.data.name !== undefined) {
+    const name = parsed.data.name.trim()
+    if (!name) return NextResponse.json({ error: 'O nome não pode ficar vazio.' }, { status: 400 })
+
+    const [clash] = await db
+      .select({ id: categories.id })
+      .from(categories)
+      .where(and(eq(categories.name, name), ne(categories.id, id), isNull(categories.archivedAt)))
+      .limit(1)
+    if (clash) return NextResponse.json({ error: `Já existe uma categoria "${name}".` }, { status: 409 })
+
+    // O slug nao muda junto: ele e a chave que o importador e as regras usam
+    // para reencontrar a categoria. Renomear e so a etiqueta.
+    patch.name = name
+  }
+
+  if (parsed.data.colorKey !== undefined) {
+    patch.color = slotByKey(parsed.data.colorKey).key
+    patch.colorDark = null
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: 'Nada para alterar.' }, { status: 400 })
+  }
+
+  const [updated] = await db.update(categories).set(patch).where(eq(categories.id, id)).returning()
+  return NextResponse.json({ id: updated!.id, name: updated!.name })
+}
+
+/**
+ * Arquiva a categoria em vez de apagar.
+ *
+ * Apagar exigiria decidir o que fazer com os lancamentos antigos, e qualquer
+ * escolha ai reescreve historico: ou eles perdem a categoria, ou somem. Arquivar
+ * tira a categoria das listas novas e preserva o que ja foi lancado.
+ */
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 })
+
+  const { id } = await ctx.params
+
+  const [cat] = await db.select().from(categories).where(eq(categories.id, id)).limit(1)
+  if (!cat) return NextResponse.json({ error: 'Categoria não encontrada' }, { status: 404 })
+
+  const [tally] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(transactions)
+    .where(eq(transactions.categoryId, id))
+
+  await db.update(categories).set({ archivedAt: new Date() }).where(eq(categories.id, id))
+
+  return NextResponse.json({ archived: true, keptTransactions: tally?.count ?? 0 })
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { asc, eq, isNull } from 'drizzle-orm'
+import { auth } from '@/auth'
+import { db } from '@/db'
+import { categories } from '@/db/schema'
+import {
+  CATEGORY_PALETTE,
+  nextFreeSlot,
+  resolveColors,
+  slotByKey,
+  slugify,
+} from '@/lib/categories/palette'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 })
+
+  const rows = await db
+    .select()
+    .from(categories)
+    .where(isNull(categories.archivedAt))
+    .orderBy(asc(categories.sortOrder), asc(categories.name))
+
+  return NextResponse.json({
+    categories: rows.map((c) => ({
+      id: c.id,
+      slug: c.slug,
+      name: c.name,
+      colorKey: c.color?.startsWith('#') ? null : c.color,
+      colors: resolveColors(c.color, c.colorDark),
+    })),
+    palette: CATEGORY_PALETTE,
+  })
+}
+
+const PostSchema = z.object({
+  name: z.string().min(1).max(40),
+  /** Chave de slot da paleta; ausente escolhe o proximo livre. */
+  colorKey: z.string().max(20).nullable().optional(),
+})
+
+export async function POST(req: Request) {
+  const session = await auth()
+  if (!session?.user) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 })
+
+  let parsed
+  try {
+    parsed = PostSchema.safeParse(await req.json())
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido' }, { status: 400 })
+  }
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Escreva o nome da categoria.' }, { status: 400 })
+  }
+
+  const name = parsed.data.name.trim()
+  const slug = slugify(name)
+  if (!slug) {
+    return NextResponse.json({ error: 'Esse nome não gera um identificador válido.' }, { status: 400 })
+  }
+
+  const [existing] = await db.select().from(categories).where(eq(categories.slug, slug)).limit(1)
+  if (existing) {
+    // Recriar uma arquivada e reativar, nao duplicar: os lancamentos antigos
+    // continuam apontando para ela.
+    if (existing.archivedAt) {
+      const [revived] = await db
+        .update(categories)
+        .set({ archivedAt: null, name })
+        .where(eq(categories.id, existing.id))
+        .returning()
+      return NextResponse.json({ id: revived!.id, slug: revived!.slug, revived: true })
+    }
+    return NextResponse.json({ error: `Já existe uma categoria "${existing.name}".` }, { status: 409 })
+  }
+
+  const all = await db.select({ color: categories.color }).from(categories)
+  const slot = parsed.data.colorKey
+    ? slotByKey(parsed.data.colorKey)
+    : nextFreeSlot(all.map((c) => c.color))
+
+  const [created] = await db
+    .insert(categories)
+    .values({
+      slug,
+      name,
+      color: slot.key,
+      colorDark: null,
+      sortOrder: all.length,
+    })
+    .returning()
+
+  return NextResponse.json({ id: created!.id, slug: created!.slug, name: created!.name })
+}

--- a/src/app/categorias/page.module.css
+++ b/src/app/categorias/page.module.css
@@ -1,0 +1,11 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.body {
+  padding: clamp(1rem, 3vw, 1.8rem);
+  max-width: 62rem;
+  width: 100%;
+}

--- a/src/app/categorias/page.tsx
+++ b/src/app/categorias/page.tsx
@@ -1,0 +1,44 @@
+import { asc, eq, isNull, sql } from 'drizzle-orm'
+import { db } from '@/db'
+import { categories, transactions } from '@/db/schema'
+import { CATEGORY_PALETTE, resolveColors } from '@/lib/categories/palette'
+import { AppHeader } from '@/components/app-header'
+import { CategoriesManager } from '@/components/categories-manager'
+import styles from './page.module.css'
+
+export const dynamic = 'force-dynamic'
+
+export default async function CategoriasPage() {
+  const rows = await db
+    .select({
+      id: categories.id,
+      slug: categories.slug,
+      name: categories.name,
+      color: categories.color,
+      colorDark: categories.colorDark,
+      transactionCount: sql<number>`count(${transactions.id})::int`,
+    })
+    .from(categories)
+    .leftJoin(transactions, eq(transactions.categoryId, categories.id))
+    .where(isNull(categories.archivedAt))
+    .groupBy(categories.id)
+    .orderBy(asc(categories.sortOrder), asc(categories.name))
+
+  const items = rows.map((c) => ({
+    id: c.id,
+    slug: c.slug,
+    name: c.name,
+    colorKey: c.color?.startsWith('#') ? null : c.color,
+    colors: resolveColors(c.color, c.colorDark),
+    transactionCount: c.transactionCount ?? 0,
+  }))
+
+  return (
+    <main className={styles.page}>
+      <AppHeader title="Categorias" subtitle="crie, renomeie e escolha a cor" />
+      <div className={styles.body}>
+        <CategoriesManager initial={items} palette={CATEGORY_PALETTE} />
+      </div>
+    </main>
+  )
+}

--- a/src/app/m/[month]/page.tsx
+++ b/src/app/m/[month]/page.tsx
@@ -10,6 +10,13 @@ import { MonthNav } from '@/components/month-nav'
 import { CashflowChart } from '@/components/cashflow-chart'
 import { MonthSummaryCard } from '@/components/month-summary-card'
 import { LedgerTable } from '@/components/ledger-table'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc.js'
+import timezone from 'dayjs/plugin/timezone.js'
+import { TZ } from '@/lib/nl/resolve'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
 import { getLedger } from '@/lib/ledger'
 import { getFlowItems, getOpeningBalance } from '@/lib/cashflow/queries'
 import { projectCashflow, upcomingCommitments } from '@/lib/cashflow/project'
@@ -112,7 +119,9 @@ export default async function MonthPage({ params }: { params: Promise<{ month: s
 
 
         <section aria-label="Lançamentos do mês">
-          <LedgerTable ledger={ledger} month={month} />
+          {/* "Hoje" e resolvido no servidor, no fuso do Joao: o relogio do
+              browser pode estar em outro fuso e pintaria a linha errada. */}
+          <LedgerTable ledger={ledger} month={month} today={dayjs().tz(TZ).format('YYYY-MM-DD')} />
         </section>
 
         <div className={styles.columns}>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -20,6 +20,7 @@ const LINKS = [
   { href: '/chat' as const, label: 'Chat' },
   { href: '/historico' as const, label: 'Histórico' },
   { href: '/metas' as const, label: 'Metas' },
+  { href: '/categorias' as const, label: 'Categorias' },
   { href: '/planos' as const, label: 'Planos' },
   { href: '/conta' as const, label: 'Conta' },
 ]

--- a/src/components/categories-manager.module.css
+++ b/src/components/categories-manager.module.css
@@ -1,0 +1,243 @@
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.newRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.newInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 22rem;
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.5rem 0.8rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-strong);
+  background: var(--bg-sunken);
+  color: var(--ink);
+}
+
+.newInput:focus {
+  outline: none;
+  border-color: var(--brand);
+}
+
+.create {
+  font-weight: 700;
+  font-size: 0.84rem;
+  padding: 0.5rem 1.1rem;
+  border-radius: var(--radius-sm);
+  background: var(--brand);
+  color: var(--brand-ink);
+  white-space: nowrap;
+}
+
+.create:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.8rem;
+  border-bottom: 1px solid var(--line);
+  flex-wrap: wrap;
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+/* O ponto e reforco da cor; o nome ao lado e que carrega a identidade. */
+.dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  flex: none;
+  background: var(--cat-light, var(--ink-faint));
+}
+
+:root[data-theme='dark'] .dot,
+:root[data-theme='dark'] .swatch {
+  background: var(--cat-dark, var(--ink-faint));
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .dot,
+  :root:not([data-theme='light']) .swatch {
+    background: var(--cat-dark, var(--ink-faint));
+  }
+}
+
+.name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ink);
+  text-align: left;
+  padding: 0.15rem 0.3rem;
+  margin-left: -0.3rem;
+  border-radius: 4px;
+}
+
+.name:hover:not(:disabled) {
+  background: var(--bg-sunken);
+}
+
+.nameEdit {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.nameInput {
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--brand);
+  background: var(--bg-sunken);
+  color: var(--ink);
+  width: 12rem;
+}
+
+.nameInput:focus {
+  outline: none;
+}
+
+.count {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.swatches {
+  display: flex;
+  gap: 0.25rem;
+}
+
+/* Alvo de 1.5rem: maior que o ponto de 0.7rem que ele representa. */
+.swatch {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: var(--cat-light, var(--ink-faint));
+  background-clip: content-box;
+  padding: 3px;
+  transition: transform 0.1s ease, border-color 0.1s ease;
+}
+
+.swatch:hover:not(:disabled) {
+  transform: scale(1.15);
+}
+
+/* A cor escolhida ganha anel na cor da tinta, nao na cor dela mesma: um anel
+   colorido sobre a propria cor nao se le. */
+.swatchOn {
+  border-color: var(--ink);
+}
+
+.swatch:disabled {
+  cursor: default;
+}
+
+.save {
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--brand);
+  color: var(--brand-ink);
+}
+
+.ghost {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-sm);
+  color: var(--ink-soft);
+}
+
+.ghost:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--bg-sunken);
+}
+
+.archive {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-sm);
+  color: var(--ink-faint);
+}
+
+.archive:hover:not(:disabled) {
+  color: var(--danger);
+  background: var(--danger-subtle);
+}
+
+.confirmBar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0.4rem 0.2rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--danger-subtle);
+  border: 1px solid var(--danger);
+  flex-wrap: wrap;
+}
+
+.confirmText {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--danger);
+}
+
+/* Fundo da superficie com texto em --danger: no dark o --danger e claro e
+   texto branco em cima dele reprovaria no contraste. */
+.archiveYes {
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--danger);
+  color: var(--danger);
+  white-space: nowrap;
+}
+
+.archiveYes:hover:not(:disabled) {
+  background: var(--danger);
+  color: var(--bg);
+}
+
+.error {
+  font-size: 0.82rem;
+  color: var(--danger);
+}
+
+.note {
+  font-size: 0.76rem;
+  color: var(--ink-faint);
+  line-height: 1.5;
+  max-width: 46rem;
+}

--- a/src/components/categories-manager.tsx
+++ b/src/components/categories-manager.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { PaletteSlot } from '@/lib/categories/palette'
+import styles from './categories-manager.module.css'
+
+/**
+ * Criar, renomear, recolorir e arquivar categoria.
+ *
+ * O slug nunca muda ao renomear: ele e a chave que o importador de planilha e as
+ * regras de recorrencia usam para reencontrar a categoria. Renomear troca so a
+ * etiqueta que aparece na tela.
+ */
+
+export interface CategoryItem {
+  id: string
+  slug: string
+  name: string
+  colorKey: string | null
+  colors: { light: string; dark: string }
+  transactionCount: number
+}
+
+export function CategoriesManager({
+  initial,
+  palette,
+}: {
+  initial: CategoryItem[]
+  palette: PaletteSlot[]
+}) {
+  const router = useRouter()
+  /* A lista vem do servidor a cada refresh. Guardar numa copia local congelaria
+   * ela: criar categoria gravava no banco e a tela nao mudava. */
+  const items = initial
+  const [newName, setNewName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState<string | null>(null)
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault()
+    const name = newName.trim()
+    if (!name || busy) return
+
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error ?? 'Não deu para criar.')
+        return
+      }
+      setNewName('')
+      router.refresh()
+    } catch {
+      setError('Falha de rede.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function patch(id: string, body: { name?: string; colorKey?: string }) {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/categories/${id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error ?? 'Não deu para salvar.')
+        return false
+      }
+      router.refresh()
+      return true
+    } catch {
+      setError('Falha de rede.')
+      return false
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function archive(id: string) {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/categories/${id}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error ?? 'Não deu para arquivar.')
+        return
+      }
+      setConfirming(null)
+      router.refresh()
+    } catch {
+      setError('Falha de rede.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <form onSubmit={create} className={styles.newRow}>
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Nome da nova categoria"
+          className={styles.newInput}
+          disabled={busy}
+          aria-label="Nome da nova categoria"
+          maxLength={40}
+        />
+        <button type="submit" className={styles.create} disabled={busy || !newName.trim()}>
+          Criar
+        </button>
+      </form>
+
+      {error && (
+        <p className={styles.error} role="alert">
+          {error}
+        </p>
+      )}
+
+      <ul className={styles.list}>
+        {items.map((c) => (
+          <li key={c.id} className={styles.item}>
+            <span
+              className={styles.dot}
+              style={
+                {
+                  '--cat-light': c.colors.light,
+                  '--cat-dark': c.colors.dark,
+                } as React.CSSProperties
+              }
+              aria-hidden
+            />
+
+            {editing === c.id ? (
+              <NameEdit
+                initial={c.name}
+                busy={busy}
+                onCancel={() => setEditing(null)}
+                onSave={async (name) => {
+                  if (await patch(c.id, { name })) setEditing(null)
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                className={styles.name}
+                onClick={() => setEditing(c.id)}
+                disabled={busy}
+              >
+                {c.name}
+              </button>
+            )}
+
+            <span className={`${styles.count} tnum`}>
+              {c.transactionCount} {c.transactionCount === 1 ? 'lançamento' : 'lançamentos'}
+            </span>
+
+            <span className={styles.swatches} role="group" aria-label={`Cor de ${c.name}`}>
+              {palette.map((slot) => (
+                <button
+                  key={slot.key}
+                  type="button"
+                  className={`${styles.swatch} ${c.colorKey === slot.key ? styles.swatchOn : ''}`}
+                  style={
+                    {
+                      '--cat-light': slot.light,
+                      '--cat-dark': slot.dark,
+                    } as React.CSSProperties
+                  }
+                  title={slot.name}
+                  aria-label={slot.name}
+                  aria-pressed={c.colorKey === slot.key}
+                  disabled={busy}
+                  onClick={() => patch(c.id, { colorKey: slot.key })}
+                />
+              ))}
+            </span>
+
+            {confirming === c.id ? (
+              <span className={styles.confirmBar}>
+                <span className={styles.confirmText}>
+                  Arquivar? Os {c.transactionCount} lançamentos ficam como estão.
+                </span>
+                <button
+                  type="button"
+                  className={styles.archiveYes}
+                  onClick={() => archive(c.id)}
+                  disabled={busy}
+                >
+                  Arquivar
+                </button>
+                <button
+                  type="button"
+                  className={styles.ghost}
+                  onClick={() => setConfirming(null)}
+                  disabled={busy}
+                >
+                  Não
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                className={styles.archive}
+                onClick={() => setConfirming(c.id)}
+                disabled={busy}
+              >
+                Arquivar
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <p className={styles.note}>
+        Arquivar tira a categoria das listas novas e mantém o que já foi lançado. Renomear troca só a
+        etiqueta: o identificador interno continua o mesmo, então o importador de planilha segue
+        reconhecendo a categoria.
+      </p>
+    </div>
+  )
+}
+
+function NameEdit({
+  initial,
+  busy,
+  onSave,
+  onCancel,
+}: {
+  initial: string
+  busy: boolean
+  onSave: (name: string) => void
+  onCancel: () => void
+}) {
+  const [value, setValue] = useState(initial)
+
+  return (
+    <span className={styles.nameEdit}>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className={styles.nameInput}
+        disabled={busy}
+        maxLength={40}
+        autoFocus
+        aria-label="Novo nome"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onSave(value.trim())
+          if (e.key === 'Escape') onCancel()
+        }}
+      />
+      <button
+        type="button"
+        className={styles.save}
+        onClick={() => onSave(value.trim())}
+        disabled={busy || !value.trim()}
+      >
+        Salvar
+      </button>
+      <button type="button" className={styles.ghost} onClick={onCancel} disabled={busy}>
+        Cancelar
+      </button>
+    </span>
+  )
+}

--- a/src/components/ledger-row-editor.tsx
+++ b/src/components/ledger-row-editor.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { LedgerRow } from '@/lib/ledger'
+import { useCategories } from './use-categories'
 import styles from './ledger-row-editor.module.css'
 
 /**
@@ -11,16 +12,6 @@ import styles from './ledger-row-editor.module.css'
  * O valor aceita formula ("=4*550"), do mesmo jeito que a planilha. Quem
  * avalia e o servidor, com Decimal.
  */
-
-const CATEGORIES = [
-  { slug: 'casa', name: 'Casa' },
-  { slug: 'transporte', name: 'Transporte' },
-  { slug: 'saude', name: 'Saúde' },
-  { slug: 'alimentacao', name: 'Alimentação' },
-  { slug: 'lazer', name: 'Lazer' },
-  { slug: 'investimento', name: 'Investimento' },
-  { slug: 'outros', name: 'Outros' },
-]
 
 export function LedgerRowEditor({
   row,
@@ -37,6 +28,7 @@ export function LedgerRowEditor({
   const [day, setDay] = useState(String(row.dueDay))
   const [categorySlug, setCategorySlug] = useState(row.categorySlug ?? '')
   const [paid, setPaid] = useState(row.paid)
+  const categories = useCategories()
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   /* confirm() nativo e sincrono: trava o renderer inteiro enquanto o dialogo
@@ -152,7 +144,7 @@ export function LedgerRowEditor({
             disabled={busy}
           >
             <option value="">Sem categoria</option>
-            {CATEGORIES.map((c) => (
+            {categories.map((c) => (
               <option key={c.slug} value={c.slug}>
                 {c.name}
               </option>

--- a/src/components/ledger-table.module.css
+++ b/src/components/ledger-table.module.css
@@ -132,9 +132,70 @@
   background: var(--bg-sunken);
 }
 
-.rowDue {
-  /* Nao pago: um respingo do tom da coluna na borda esquerda. */
-  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--tone) 40%, transparent);
+/* As quatro faixas da formatacao condicional da planilha.
+ *
+ * A cor de fundo e fraca de proposito: ela classifica a linha, nao compete com
+ * o valor. A barra esquerda de 3px e o que se le de longe, e ela sobrevive a
+ * modo de alto contraste, onde o color-mix do fundo desaparece. */
+
+/* Pago: sem alarme, so a marca discreta de que ja resolveu. */
+.row_paid {
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--ok) 45%, transparent);
+}
+
+/* Atrasado: venceu e ninguem pagou. */
+.row_overdue {
+  background: color-mix(in srgb, var(--danger-subtle) 70%, transparent);
+  box-shadow: inset 3px 0 0 var(--danger);
+}
+
+.row_overdue:hover {
+  background: var(--danger-subtle);
+}
+
+/* Vence em ate 3 dias: o amarelo da formula original. */
+.row_due_soon {
+  background: color-mix(in srgb, var(--warn-subtle) 70%, transparent);
+  box-shadow: inset 3px 0 0 var(--warn);
+}
+
+.row_due_soon:hover {
+  background: var(--warn-subtle);
+}
+
+/* Em aberto e sem pressa: branco, sem faixa. Como na planilha. */
+.row_open {
+  box-shadow: inset 3px 0 0 transparent;
+}
+
+/* A zebra nao pode apagar a faixa de estado. */
+.table tbody tr.row_overdue:nth-child(even) {
+  background: color-mix(in srgb, var(--danger-subtle) 85%, transparent);
+}
+
+.table tbody tr.row_due_soon:nth-child(even) {
+  background: color-mix(in srgb, var(--warn-subtle) 85%, transparent);
+}
+
+/* Ponto da categoria: reforco do nome que vem ao lado, nunca sozinho. */
+.catDot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  margin-right: 0.35rem;
+  vertical-align: baseline;
+  background: var(--cat-light, var(--ink-faint));
+}
+
+:root[data-theme='dark'] .catDot {
+  background: var(--cat-dark, var(--ink-faint));
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .catDot {
+    background: var(--cat-dark, var(--ink-faint));
+  }
 }
 
 .tdDay {

--- a/src/components/ledger-table.tsx
+++ b/src/components/ledger-table.tsx
@@ -6,6 +6,7 @@ import { formatBRL } from '@/lib/month-summary'
 import { LedgerRowEditor } from './ledger-row-editor'
 import { PaidToggle } from './paid-toggle'
 import { NewRowForm } from './new-row-form'
+import { dueStatus, type DueStatus } from '@/lib/due-status'
 import styles from './ledger-table.module.css'
 
 /**
@@ -14,8 +15,28 @@ import styles from './ledger-table.module.css'
  * Cada linha e clicavel e abre o editor inline: nome, valor, dia, categoria e
  * status. Usa a linguagem de cor da planilha (despesa avermelhada, receita
  * esverdeada) para o Joao reconhecer o ambiente.
+ *
+ * As quatro faixas da formatacao condicional da planilha continuam valendo:
+ * pago, atrasado, vence em ate 3 dias, e em aberto (sem cor).
  */
-export function LedgerTable({ ledger, month }: { ledger: Ledger; month: string }) {
+/* Mapa explicito: 'due-soon' tem hifen e nao vira nome de classe por template. */
+const ROW_CLASS: Record<DueStatus, string> = {
+  paid: styles.row_paid!,
+  overdue: styles.row_overdue!,
+  'due-soon': styles.row_due_soon!,
+  open: styles.row_open!,
+}
+
+export function LedgerTable({
+  ledger,
+  month,
+  today,
+}: {
+  ledger: Ledger
+  month: string
+  /** Vem do servidor: o "hoje" do fuso do Joao, nao o do relogio do browser. */
+  today: string
+}) {
   const [editing, setEditing] = useState<string | null>(null)
   const [adding, setAdding] = useState<'expense' | 'income' | null>(null)
 
@@ -32,6 +53,7 @@ export function LedgerTable({ ledger, month }: { ledger: Ledger; month: string }
         setEditing={setEditing}
         adding={adding === 'expense'}
         setAdding={setAdding}
+        today={today}
       />
       <LedgerColumn
         title="Receitas"
@@ -44,6 +66,7 @@ export function LedgerTable({ ledger, month }: { ledger: Ledger; month: string }
         setEditing={setEditing}
         adding={adding === 'income'}
         setAdding={setAdding}
+        today={today}
       />
     </div>
   )
@@ -60,6 +83,7 @@ function LedgerColumn({
   setEditing,
   adding,
   setAdding,
+  today,
 }: {
   title: string
   tone: 'expense' | 'income'
@@ -71,6 +95,7 @@ function LedgerColumn({
   setEditing: (id: string | null) => void
   adding: boolean
   setAdding: (k: 'expense' | 'income' | null) => void
+  today: string
 }) {
   return (
     <section className={`${styles.col} ${styles[tone]}`} aria-label={title}>
@@ -120,8 +145,9 @@ function LedgerColumn({
               </tr>
             </thead>
             <tbody>
-              {rows.map((r) =>
-                editing === r.id ? (
+              {rows.map((r) => {
+                const st = dueStatus(r, today)
+                return editing === r.id ? (
                   <tr key={r.id} className={styles.editingRow}>
                     <td colSpan={4}>
                       <LedgerRowEditor row={r} month={month} onClose={() => setEditing(null)} />
@@ -130,7 +156,7 @@ function LedgerColumn({
                 ) : (
                   <tr
                     key={r.id}
-                    className={`${r.paid ? styles.rowPaid : styles.rowDue} ${styles.clickable}`}
+                    className={`${ROW_CLASS[st]} ${styles.clickable}`}
                     onClick={() => setEditing(r.id)}
                     tabIndex={0}
                     role="button"
@@ -147,7 +173,25 @@ function LedgerColumn({
                     </td>
                     <td className={styles.tdDesc}>
                       <span className={styles.desc}>{r.description}</span>
-                      {r.categoryName && <span className={styles.cat}>{r.categoryName}</span>}
+                      {r.categoryName && (
+                        <span className={styles.cat}>
+                          {/* O ponto e reforco: o nome ao lado carrega a
+                              identidade, entao a cor nunca decide sozinha. */}
+                          <span
+                            className={styles.catDot}
+                            style={
+                              r.categoryColor
+                                ? ({
+                                    '--cat-light': r.categoryColor.light,
+                                    '--cat-dark': r.categoryColor.dark,
+                                  } as React.CSSProperties)
+                                : undefined
+                            }
+                            aria-hidden
+                          />
+                          {r.categoryName}
+                        </span>
+                      )}
                     </td>
                     <td className={`${styles.tdValue} tnum`}>{formatBRL(r.amountCents)}</td>
                     <td className={styles.tdStatus}>
@@ -159,8 +203,8 @@ function LedgerColumn({
                       />
                     </td>
                   </tr>
-                ),
-              )}
+                )
+              })}
             </tbody>
           </table>
         </div>

--- a/src/components/new-row-form.tsx
+++ b/src/components/new-row-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useCategories } from './use-categories'
 import styles from './ledger-row-editor.module.css'
 
 /**
@@ -10,16 +11,6 @@ import styles from './ledger-row-editor.module.css'
  * Reusa o CSS do editor de linha: adicionar e editar sao a mesma interacao com
  * campos diferentes preenchidos, e ter dois visuais para isso confundiria.
  */
-
-const CATEGORIES = [
-  { slug: 'casa', name: 'Casa' },
-  { slug: 'transporte', name: 'Transporte' },
-  { slug: 'saude', name: 'Saúde' },
-  { slug: 'alimentacao', name: 'Alimentação' },
-  { slug: 'lazer', name: 'Lazer' },
-  { slug: 'investimento', name: 'Investimento' },
-  { slug: 'outros', name: 'Outros' },
-]
 
 export function NewRowForm({
   kind,
@@ -36,6 +27,7 @@ export function NewRowForm({
   const [day, setDay] = useState('1')
   const [categorySlug, setCategorySlug] = useState(kind === 'expense' ? 'outros' : '')
   const [paid, setPaid] = useState(false)
+  const categories = useCategories()
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -141,7 +133,7 @@ export function NewRowForm({
               disabled={busy}
             >
               <option value="">Sem categoria</option>
-              {CATEGORIES.map((c) => (
+              {categories.map((c) => (
                 <option key={c.slug} value={c.slug}>
                   {c.name}
                 </option>

--- a/src/components/use-categories.ts
+++ b/src/components/use-categories.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * As categorias vivas, vindas do banco.
+ *
+ * Antes os dois formularios carregavam a mesma lista fixa no codigo, entao uma
+ * categoria criada em /categorias nunca aparecia na hora de lancar.
+ */
+
+export interface CategoryOption {
+  slug: string
+  name: string
+}
+
+let cache: CategoryOption[] | null = null
+
+export function useCategories(): CategoryOption[] {
+  const [items, setItems] = useState<CategoryOption[]>(cache ?? [])
+
+  useEffect(() => {
+    let alive = true
+    fetch('/api/categories')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!alive || !d?.categories) return
+        const next = d.categories.map((c: { slug: string; name: string }) => ({
+          slug: c.slug,
+          name: c.name,
+        }))
+        cache = next
+        setItems(next)
+      })
+      .catch(() => {
+        // Falhou: o select fica com o que ja tinha. Melhor uma lista velha do
+        // que um formulario sem categoria nenhuma.
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  return items
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -141,7 +141,13 @@ export const categories = pgTable(
     slug: text().notNull(), // 'casa', 'alimentacao', ...
     name: text().notNull(),
     parentId: uuid().references((): any => categories.id),
+    /* Duas cores porque o dark nao e um flip do light: cada passo e escolhido
+     * contra a sua propria superficie. Ver lib/categories/palette.ts. */
     color: text(),
+    colorDark: text(),
+    /* Ordem na lista de configuracao; empate cai no nome. */
+    sortOrder: integer().notNull().default(0),
+    archivedAt: timestamp({ withTimezone: true }),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [uniqueIndex('categories_slug_key').on(t.slug)],

--- a/src/lib/categories/palette.test.ts
+++ b/src/lib/categories/palette.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CATEGORY_PALETTE,
+  NEUTRAL_SLOT,
+  nextFreeSlot,
+  resolveColors,
+  slotByKey,
+  slugify,
+} from './palette'
+
+describe('paleta de categorias', () => {
+  it('nao repete cor entre slots, em nenhum dos dois temas', () => {
+    const light = CATEGORY_PALETTE.map((s) => s.light)
+    const dark = CATEGORY_PALETTE.map((s) => s.dark)
+    expect(new Set(light).size).toBe(light.length)
+    // Verde e o unico passo que serve aos dois temas sem mudar.
+    expect(new Set(dark).size).toBe(dark.length)
+  })
+
+  it('cor desconhecida cai no cinza, nao quebra', () => {
+    expect(slotByKey('cor-que-nao-existe')).toBe(NEUTRAL_SLOT)
+    expect(slotByKey(null)).toBe(NEUTRAL_SLOT)
+  })
+
+  it('atribui slots em ordem fixa, sem ciclar', () => {
+    expect(nextFreeSlot([]).key).toBe('blue')
+    expect(nextFreeSlot(['blue']).key).toBe('orange')
+    expect(nextFreeSlot(['blue', 'orange', 'aqua']).key).toBe('yellow')
+  })
+
+  it('passado o fim da paleta cai no cinza, sem inventar hue', () => {
+    const todos = CATEGORY_PALETTE.map((s) => s.key)
+    expect(nextFreeSlot(todos)).toBe(NEUTRAL_SLOT)
+  })
+
+  it('arquivar uma categoria nao repinta as outras', () => {
+    // O slot livre depende de quem AINDA usa a cor, nao da posicao na lista.
+    expect(nextFreeSlot(['blue', 'aqua']).key).toBe('orange')
+  })
+
+  it('le tanto chave de slot quanto o hex antigo semeado no banco', () => {
+    expect(resolveColors('blue', null).light).toBe('#2a78d6')
+    expect(resolveColors('#6d28d9', null)).toEqual({ light: '#6d28d9', dark: '#6d28d9' })
+    expect(resolveColors('#6d28d9', '#a78bfa')).toEqual({ light: '#6d28d9', dark: '#a78bfa' })
+  })
+})
+
+describe('slugify', () => {
+  it('tira acento e espaco', () => {
+    expect(slugify('Alimentação')).toBe('alimentacao')
+    expect(slugify('Saúde da Zaya')).toBe('saude-da-zaya')
+    expect(slugify('Cartão  João')).toBe('cartao-joao')
+  })
+
+  it('nao deixa hifen sobrando nas pontas', () => {
+    expect(slugify('  Casa  ')).toBe('casa')
+    expect(slugify('!!! Lazer !!!')).toBe('lazer')
+  })
+
+  it('devolve vazio quando nao sobra nada utilizavel', () => {
+    expect(slugify('!!!')).toBe('')
+    expect(slugify('   ')).toBe('')
+  })
+})

--- a/src/lib/categories/palette.ts
+++ b/src/lib/categories/palette.ts
@@ -1,0 +1,93 @@
+/**
+ * Paleta das categorias.
+ *
+ * Sao slots fixos, atribuidos em ordem e nunca ciclados: a cor segue a
+ * categoria, nao a posicao dela numa lista filtrada. Se o Joao arquivar
+ * "Lazer", as outras nao se repintam.
+ *
+ * Cada slot tem um passo proprio para o claro e para o escuro. O dark nao e um
+ * flip do light: os dois foram escolhidos contra a sua propria superficie e
+ * validados (banda de luminosidade, piso de croma, separacao para daltonismo e
+ * contraste) com o validador da skill de dataviz.
+ *
+ * No claro, tres passos ficam abaixo de 3:1 contra o fundo. Isso e aceitavel
+ * aqui porque a cor nunca carrega sozinha a identidade: o nome da categoria
+ * aparece sempre ao lado do ponto colorido.
+ */
+
+export interface PaletteSlot {
+  /** Chave guardada no banco, nao o hex: trocar a paleta nao migra dado. */
+  key: string
+  name: string
+  light: string
+  dark: string
+}
+
+export const CATEGORY_PALETTE: PaletteSlot[] = [
+  { key: 'blue', name: 'Azul', light: '#2a78d6', dark: '#3987e5' },
+  { key: 'orange', name: 'Laranja', light: '#eb6834', dark: '#d95926' },
+  { key: 'aqua', name: 'Verde-água', light: '#1baf7a', dark: '#199e70' },
+  { key: 'yellow', name: 'Amarelo', light: '#eda100', dark: '#c98500' },
+  { key: 'magenta', name: 'Magenta', light: '#e87ba4', dark: '#d55181' },
+  { key: 'green', name: 'Verde', light: '#008300', dark: '#008300' },
+  { key: 'violet', name: 'Violeta', light: '#4a3aa7', dark: '#9085e9' },
+]
+
+const BY_KEY = new Map(CATEGORY_PALETTE.map((s) => [s.key, s]))
+
+/** Sem categoria, ou cor desconhecida: cinza declarado, nao um hue inventado. */
+export const NEUTRAL_SLOT: PaletteSlot = {
+  key: 'neutral',
+  name: 'Cinza',
+  light: '#6b7280',
+  dark: '#9ca3af',
+}
+
+export function slotByKey(key: string | null | undefined): PaletteSlot {
+  if (!key) return NEUTRAL_SLOT
+  return BY_KEY.get(key) ?? NEUTRAL_SLOT
+}
+
+/**
+ * O proximo slot livre, em ordem fixa.
+ *
+ * Passado o fim da paleta, cai no cinza em vez de gerar um hue novo: uma cor
+ * inventada nao passaria pelas checagens de daltonismo contra as existentes.
+ */
+export function nextFreeSlot(usedKeys: Iterable<string | null>): PaletteSlot {
+  const used = new Set([...usedKeys].filter((k): k is string => !!k))
+  return CATEGORY_PALETTE.find((s) => !used.has(s.key)) ?? NEUTRAL_SLOT
+}
+
+/**
+ * Resolve o par (claro, escuro) de uma categoria.
+ *
+ * Aceita tanto a chave de slot quanto um hex cru, porque as categorias antigas
+ * foram semeadas com hex direto na coluna `color`.
+ */
+export function resolveColors(
+  color: string | null,
+  colorDark: string | null,
+): { light: string; dark: string } {
+  if (color?.startsWith('#')) {
+    return { light: color, dark: colorDark ?? color }
+  }
+  const slot = slotByKey(color)
+  return { light: slot.light, dark: slot.dark }
+}
+
+/**
+ * Slug a partir do nome: sem acento, sem espaco, estavel.
+ *
+ * Fica aqui, e nao na rota, porque a rota importa `auth` e arrasta o runtime do
+ * Next junto: uma funcao de string nao deveria precisar disso para ser testada.
+ */
+export function slugify(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+}

--- a/src/lib/due-status.test.ts
+++ b/src/lib/due-status.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { addDays, dueStatus } from './due-status'
+
+const TODAY = '2026-08-15'
+
+function status(dueDate: string, paid = false, today = TODAY) {
+  return dueStatus({ paid, dueDate }, today)
+}
+
+describe('dueStatus', () => {
+  it('pago vence qualquer outro estado, mesmo atrasado', () => {
+    expect(status('2026-08-01', true)).toBe('paid')
+    expect(status('2026-12-31', true)).toBe('paid')
+  })
+
+  it('marca atraso so antes de hoje', () => {
+    expect(status('2026-08-14')).toBe('overdue')
+    expect(status('2026-08-15')).not.toBe('overdue')
+  })
+
+  it('a janela do amarelo e hoje ate hoje+3, inclusive nas pontas', () => {
+    expect(status('2026-08-15')).toBe('due-soon')
+    expect(status('2026-08-18')).toBe('due-soon')
+    expect(status('2026-08-19')).toBe('open')
+  })
+
+  it('a janela atravessa a virada do mes', () => {
+    // Onde a formula da planilha quebrava: DAY(30)+3 = 33 nao existe, entao
+    // dia 1 do mes seguinte nunca ficava amarelo.
+    expect(status('2026-09-01', false, '2026-08-30')).toBe('due-soon')
+    expect(status('2026-09-02', false, '2026-08-30')).toBe('due-soon')
+    expect(status('2026-09-03', false, '2026-08-31')).toBe('due-soon')
+    expect(status('2026-09-04', false, '2026-08-31')).toBe('open')
+  })
+
+  it('atravessa a virada do ano', () => {
+    expect(status('2027-01-01', false, '2026-12-30')).toBe('due-soon')
+    expect(status('2026-12-31', false, '2027-01-02')).toBe('overdue')
+  })
+
+  it('nao inventa estado em meses que nao sao o atual', () => {
+    // Mes passado inteiro em aberto: tudo atrasado, nada amarelo.
+    expect(status('2026-07-10')).toBe('overdue')
+    // Mes futuro: nada atrasado, nada amarelo.
+    expect(status('2026-10-10')).toBe('open')
+  })
+})
+
+describe('addDays', () => {
+  it('atravessa mes, ano e ano bissexto', () => {
+    expect(addDays('2026-08-30', 3)).toBe('2026-09-02')
+    expect(addDays('2026-12-31', 1)).toBe('2027-01-01')
+    expect(addDays('2028-02-27', 3)).toBe('2028-03-01')
+    expect(addDays('2026-02-27', 3)).toBe('2026-03-02')
+  })
+})

--- a/src/lib/due-status.ts
+++ b/src/lib/due-status.ts
@@ -1,0 +1,43 @@
+/**
+ * O estado de um lancamento na tabela: a formatacao condicional da planilha.
+ *
+ * O Joao usava quatro regras no Sheets. A do amarelo era:
+ *
+ *   =AND($C2=""; $D2>=DAY(TODAY()); $D2<=DAY(TODAY())+3)
+ *
+ * Ou seja: nao pago E vence de hoje ate daqui a 3 dias. Aqui vale a mesma
+ * ideia, com duas diferencas que a planilha nao tinha como resolver:
+ *
+ * 1. A planilha comparava DIA do mes (DAY), entao no fim do mes a janela
+ *    quebrava: dia 30 + 3 = 33, que nao existe. Aqui a comparacao e por data
+ *    completa, entao a janela atravessa o mes.
+ * 2. Meses que nao sao o atual nao tem "hoje". Um mes passado nao fica todo
+ *    vermelho, nem um mes futuro todo amarelo.
+ */
+
+export type DueStatus = 'paid' | 'overdue' | 'due-soon' | 'open'
+
+/** Dias de antecedencia do amarelo, como o +3 da formula original. */
+export const SOON_WINDOW_DAYS = 3
+
+export function dueStatus(
+  { paid, dueDate }: { paid: boolean; dueDate: string },
+  today: string,
+): DueStatus {
+  if (paid) return 'paid'
+
+  // Comparacao lexicografica: YYYY-MM-DD ordena como data, sem fuso no meio.
+  if (dueDate < today) return 'overdue'
+
+  const limit = addDays(today, SOON_WINDOW_DAYS)
+  if (dueDate <= limit) return 'due-soon'
+
+  return 'open'
+}
+
+/** Soma dias a uma data ISO, atravessando mes e ano. */
+export function addDays(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number) as [number, number, number]
+  const dt = new Date(Date.UTC(y, m - 1, d + days))
+  return dt.toISOString().slice(0, 10)
+}

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, gte, lte } from 'drizzle-orm'
 import { db } from '@/db'
 import { transactions, categories, contexts } from '@/db/schema'
+import { resolveColors } from './categories/palette'
 
 /**
  * A tabela de lancamentos: o que a planilha mostrava e o dashboard tinha
@@ -15,6 +16,8 @@ export interface LedgerRow {
   description: string
   categorySlug: string | null
   categoryName: string | null
+  /** Par (claro, escuro) ja resolvido: a tabela nao precisa saber de paleta. */
+  categoryColor: { light: string; dark: string } | null
   dueDay: number
   /** YYYY-MM-DD completo: o toggle de pago precisa da data, nao so do dia. */
   dueDate: string
@@ -47,6 +50,8 @@ export async function getLedger(month: string, contextSlug = 'pessoal'): Promise
       description: transactions.description,
       categorySlug: categories.slug,
       categoryName: categories.name,
+      categoryColor: categories.color,
+      categoryColorDark: categories.colorDark,
       dueDate: transactions.dueDate,
       paidAt: transactions.paidAt,
     })
@@ -68,6 +73,7 @@ export async function getLedger(month: string, contextSlug = 'pessoal'): Promise
     description: r.description,
     categorySlug: r.categorySlug ?? null,
     categoryName: r.categoryName ?? null,
+    categoryColor: r.categoryName ? resolveColors(r.categoryColor, r.categoryColorDark) : null,
     dueDay: Number(r.dueDate.slice(8, 10)),
     dueDate: r.dueDate,
     paidDay: r.paidAt ? r.paidAt.getUTCDate() : null,


### PR DESCRIPTION
## As quatro faixas da planilha

Eram quatro regras de formatação condicional no Sheets. A do amarelo era:

```
=AND($C2=""; $D2>=DAY(TODAY()); $D2<=DAY(TODAY())+3)
```

Agora a tabela tem as quatro:

| Estado | Como aparece |
|---|---|
| Pago | barra verde, sem fundo |
| Atrasado | fundo vermelho suave + barra vermelha |
| Vence em até 3 dias | fundo âmbar suave + barra amarela |
| Em aberto | branco, sem faixa |

Duas diferenças em relação à planilha, ambas corrigindo limitações dela:

1. **A janela atravessa o mês.** A fórmula comparava dia do mês, então `DAY(30)+3 = 33` não existia e o dia 1 do mês seguinte nunca ficava amarelo. Aqui a comparação é por data completa.
2. **Meses que não são o atual não têm "hoje".** Um mês passado não fica todo vermelho, nem um mês futuro todo amarelo.

"Hoje" é resolvido no servidor, no fuso de São Paulo: o relógio do browser pode estar em outro fuso e pintaria a linha errada.

## As cores das categorias

Elas estavam no banco desde o começo, mas `getLedger` nunca selecionava a coluna, então nunca chegavam à tela.

A paleta virou um módulo com slots fixos, atribuídos em ordem e nunca ciclados: a cor segue a categoria, não a posição dela numa lista filtrada. Arquivar uma categoria não repinta as outras.

Cada slot tem passo próprio para claro e escuro, validados com o validador da skill de dataviz. A paleta anterior reprovava em três das cinco checagens (faixa de luminosidade, piso de croma e o piso de visão normal, com verde e verde-água a ΔE 12,3 um do outro). A nova passa nos dois modos.

O ponto colorido é sempre reforço: o nome da categoria aparece ao lado, então a cor nunca decide sozinha.

## Nova tela `/categorias`

Criar, renomear, escolher cor entre os 7 slots e arquivar, com a contagem de lançamentos de cada uma.

- **Renomear não mexe no slug.** Ele é a chave que o importador de planilha e as regras de recorrência usam para reencontrar a categoria; renomear troca só a etiqueta.
- **Arquivar em vez de apagar.** Apagar exigiria decidir o que fazer com os lançamentos antigos, e qualquer escolha aí reescreve histórico.

Os formulários de lançamento liam uma lista de categorias fixa no código, então uma categoria criada nunca aparecia na hora de lançar. Agora vêm do banco.

## Migration

`0002_categorias_e_chat.sql` cobre também `chat_messages` e `users.password_hash`, que tinham sido aplicados direto no banco e não estavam versionados.

## Verificação

- 336 testes passando (16 novos: a regra de vencimento com virada de mês e de ano, e a paleta), typecheck limpo, build compilando.
- No browser, contra o banco real: as quatro faixas lado a lado, marcar como pago tirando o vermelho, criar/renomear/recolorir categoria, e os dois modos de cor.
- Dados de teste removidos do banco depois da verificação.