### PR TITLE
chore(deps): remove minimumReleaseAgeExclude do pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,19 +1,6 @@
 allowBuilds:
   esbuild: set this to true or false
   sharp: set this to true or false
-# Gerado pelo pnpm ao instalar next@16.3.2 com menos de 24h de publicacao
-# (guarda minimumReleaseAge). Pode ser removido depois que o release envelhecer.
-minimumReleaseAgeExclude:
-  - '@next/env@16.3.2'
-  - '@next/swc-darwin-arm64@16.3.2'
-  - '@next/swc-darwin-x64@16.3.2'
-  - '@next/swc-linux-arm64-gnu@16.3.2'
-  - '@next/swc-linux-arm64-musl@16.3.2'
-  - '@next/swc-linux-x64-gnu@16.3.2'
-  - '@next/swc-linux-x64-musl@16.3.2'
-  - '@next/swc-win32-arm64-msvc@16.3.2'
-  - '@next/swc-win32-x64-msvc@16.3.2'
-  - next@16.3.2
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
Remove a lista `minimumReleaseAgeExclude` gerada pelo pnpm ao instalar o next 16.3.2. O lockfile já fixa a versão; `pnpm install --frozen-lockfile` e `pnpm install` seguem OK sem re-resolver nem re-adicionar a lista.