### PR TITLE
fix: regras de recorrencia duplicadas por caixa do label

### DIFF
--- a/scripts/merge-duplicate-rules.ts
+++ b/scripts/merge-duplicate-rules.ts
@@ -1,0 +1,156 @@
+import 'dotenv/config'
+import { sql } from 'drizzle-orm'
+import { db } from '@/db'
+
+/**
+ * Funde regras de recorrencia duplicadas apenas por caixa do label.
+ *
+ * A planilha alternava a caixa da mesma linha ('Van Zaya' e 'van zaya'), e o
+ * upsert do import comparava o label cru: cada variacao virou uma regra, com
+ * sua propria serie de ocorrencias futuras. O resultado era compromisso dobrado
+ * na projecao de fluxo de caixa. A causa esta corrigida em lib/import/persist.ts;
+ * este script limpa o passivo que ficou no banco.
+ *
+ * Sobrevivente = a regra com mais transacoes reais apontando para ela, porque
+ * e a que carrega o historico e os valores atuais. Empate cai na mais antiga.
+ *
+ * Roda em dry-run por padrao. Para gravar: --apply
+ */
+
+const TARGETS = [
+  'aparelho tauana',
+  'van zaya',
+  'lanche final de semana',
+  'cartão joão caixa',
+  'cartão joão caixa #2',
+]
+
+const apply = process.argv.includes('--apply')
+const brl = (c: number | string) => `R$ ${(Number(c) / 100).toFixed(2)}`
+
+async function main() {
+  const res = await db.execute(sql`
+    select r.id, r.label, lower(trim(r.label)) as norm, r.context_id,
+           r.starts_on, r.category_id, r.amount_cents, r.day_of_month,
+           (select count(*) from transactions t where t.rule_id = r.id) as txs
+    from recurrence_rules r
+    where lower(trim(r.label)) in (
+      'aparelho tauana','van zaya','lanche final de semana',
+      'cartão joão caixa','cartão joão caixa #2'
+    )
+    order by lower(trim(r.label)), r.starts_on
+  `)
+  const rows = ((res as any).rows ?? res) as any[]
+
+  const groups = new Map<string, any[]>()
+  for (const r of rows) {
+    const key = `${r.context_id}::${r.norm}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(r)
+  }
+
+  console.log(apply ? '=== APLICANDO ===' : '=== DRY-RUN (nada sera gravado) ===')
+
+  let totalOccRemovidas = 0
+  let totalTxRepontadas = 0
+
+  for (const [key, rules] of groups) {
+    const norm = key.split('::')[1]
+
+    // Guarda: so funde o que e realmente o mesmo label normalizado. '#2' tem
+    // chave propria, entao os dois cartoes nunca se encontram aqui.
+    const distinct = new Set(rules.map((r) => r.norm))
+    if (distinct.size !== 1) {
+      console.log(`\n!! ${norm}: grupo heterogeneo, PULANDO`)
+      continue
+    }
+    if (rules.length < 2) {
+      console.log(`\n-- ${norm}: sem duplicata, pulando`)
+      continue
+    }
+
+    const sorted = [...rules].sort(
+      (a, b) => Number(b.txs) - Number(a.txs) || String(a.starts_on).localeCompare(String(b.starts_on)),
+    )
+    const keep = sorted[0]!
+    const drop = sorted.slice(1)
+
+    console.log(`\n### ${norm}`)
+    console.log(`  MANTEM  ${keep.id.slice(0, 8)} "${keep.label}" starts=${keep.starts_on} txs=${keep.txs} valor=${brl(keep.amount_cents)}`)
+
+    for (const d of drop) {
+      const occAbertas = await db.execute(sql`
+        select count(*) as n, coalesce(sum(expected_cents), 0) as cents
+        from recurrence_occurrences
+        where rule_id = ${d.id} and transaction_id is null and skipped_at is null
+      `)
+      const oa = (((occAbertas as any).rows ?? occAbertas) as any[])[0]!
+      const occRealizadas = await db.execute(sql`
+        select count(*) as n from recurrence_occurrences
+        where rule_id = ${d.id} and transaction_id is not null
+      `)
+      const orl = (((occRealizadas as any).rows ?? occRealizadas) as any[])[0]!
+
+      console.log(`  FUNDE   ${d.id.slice(0, 8)} "${d.label}" starts=${d.starts_on} txs=${d.txs} valor=${brl(d.amount_cents)}`)
+      console.log(`          ${d.txs} transacao(oes) repontada(s) para a mantida`)
+      console.log(`          ${orl.n} ocorrencia(s) realizada(s) repontada(s)`)
+      console.log(`          ${oa.n} ocorrencia(s) futura(s) em aberto removida(s) (${brl(oa.cents)})`)
+
+      totalTxRepontadas += Number(d.txs)
+      totalOccRemovidas += Number(oa.n)
+
+      if (apply) {
+        await db.transaction(async (tx) => {
+          // Historico primeiro: transacoes reais nunca podem ficar orfas.
+          await tx.execute(sql`update transactions set rule_id = ${keep.id} where rule_id = ${d.id}`)
+
+          // Ocorrencia realizada carrega estado (o que foi pago). Migra, a nao
+          // ser que a mantida ja tenha uma no mesmo dueDate: o unique
+          // (rule, due_date) rejeitaria, e nesse caso a da mantida prevalece.
+          await tx.execute(sql`
+            update recurrence_occurrences o set rule_id = ${keep.id}
+            where o.rule_id = ${d.id} and o.transaction_id is not null
+              and not exists (
+                select 1 from recurrence_occurrences k
+                where k.rule_id = ${keep.id} and k.due_date = o.due_date
+              )
+          `)
+
+          // Previsao duplicada: some. A mantida ja projeta essas mesmas datas.
+          await tx.execute(sql`
+            delete from recurrence_occurrences
+            where rule_id = ${d.id} and transaction_id is null and skipped_at is null
+          `)
+
+          // Categoria da duplicada preenche buraco da mantida.
+          if (!keep.category_id && d.category_id) {
+            await tx.execute(sql`update recurrence_rules set category_id = ${d.category_id} where id = ${keep.id}`)
+            console.log(`          categoria herdada da fundida`)
+          }
+
+          const resto = await tx.execute(sql`
+            select count(*) as n from recurrence_occurrences where rule_id = ${d.id}
+          `)
+          const n = Number((((resto as any).rows ?? resto) as any[])[0]!.n)
+          if (n === 0) {
+            await tx.execute(sql`delete from recurrence_rules where id = ${d.id}`)
+            console.log(`          regra removida`)
+          } else {
+            // Sobrou ocorrencia com estado que nao pode migrar: desativa em vez
+            // de apagar, senao o cascade levaria o estado junto.
+            await tx.execute(sql`update recurrence_rules set active = false where id = ${d.id}`)
+            console.log(`          regra DESATIVADA (${n} ocorrencia(s) preservada(s))`)
+          }
+        })
+      }
+    }
+  }
+
+  console.log(`\n--- Resumo ---`)
+  console.log(`transacoes repontadas: ${totalTxRepontadas}`)
+  console.log(`ocorrencias futuras removidas: ${totalOccRemovidas}`)
+  if (!apply) console.log(`\nNada foi gravado. Rode com --apply para efetivar.`)
+}
+
+await main()
+process.exit(0)

--- a/src/app/m/[month]/page.module.css
+++ b/src/app/m/[month]/page.module.css
@@ -145,15 +145,7 @@
   gap: 1.5rem;
 }
 
-@media (min-width: 940px) {
-  .columns {
-    grid-template-columns: minmax(0, 1.7fr) minmax(260px, 1fr);
-    align-items: start;
-  }
-}
-
-.colMain,
-.colSide {
+.colMain {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -202,52 +194,6 @@
   padding: 1.2rem;
 }
 
-/* A pagar */
-.upList {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-}
-
-.upItem {
-  display: grid;
-  grid-template-columns: 2rem 1fr auto;
-  align-items: center;
-  gap: 0.7rem;
-  padding: 0.7rem 1.2rem;
-  border-bottom: 1px solid var(--line);
-}
-
-.upItem:last-child {
-  border-bottom: none;
-}
-
-.upDay {
-  width: 2rem;
-  height: 2rem;
-  display: grid;
-  place-items: center;
-  border-radius: var(--radius-sm);
-  background: var(--bg-sunken);
-  color: var(--ink-soft);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.upDesc {
-  font-size: 0.86rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.upValue {
-  font-size: 0.84rem;
-  font-weight: 600;
-}
-
 /* Vazio */
 .empty {
   min-height: 100vh;
@@ -275,12 +221,6 @@
   background: var(--bg-sunken);
   padding: 0.15em 0.4em;
   border-radius: 4px;
-}
-
-.allPaid {
-  padding: 1.2rem;
-  font-size: 0.86rem;
-  color: var(--ink-faint);
 }
 
 .navLink {

--- a/src/app/m/[month]/page.tsx
+++ b/src/app/m/[month]/page.tsx
@@ -19,7 +19,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 import { getLedger } from '@/lib/ledger'
 import { getFlowItems, getOpeningBalance } from '@/lib/cashflow/queries'
-import { projectCashflow, upcomingCommitments } from '@/lib/cashflow/project'
+import { projectCashflow } from '@/lib/cashflow/project'
 import { narrateInsights, type Summary } from '@/lib/insights/narrate'
 import { monthRange } from '@/lib/queries'
 import Link from 'next/link'
@@ -67,7 +67,6 @@ export default async function MonthPage({ params }: { params: Promise<{ month: s
 
   const narrated = await narrateSafely(month, insights, projection)
 
-  const upcoming = upcomingCommitments(flowItems, from, 31).slice(0, 10)
 
   return (
     <div className={styles.shell}>
@@ -162,28 +161,6 @@ export default async function MonthPage({ params }: { params: Promise<{ month: s
               </div>
             </section>
           </div>
-
-          <aside className={styles.colSide}>
-            <section className={styles.panel} aria-labelledby="up-h">
-              <div className={styles.panelHead}>
-                <h2 id="up-h" className={styles.panelTitle}>A pagar</h2>
-                <span className={styles.panelHint}>{upcoming.length} em aberto</span>
-              </div>
-              {upcoming.length === 0 ? (
-                <p className={styles.allPaid}>Tudo pago neste mês.</p>
-              ) : (
-                <ul className={styles.upList}>
-                  {upcoming.map((t) => (
-                    <li key={`${t.date}-${t.label}`} className={styles.upItem}>
-                      <span className={styles.upDay} aria-hidden>{t.date.slice(8, 10)}</span>
-                      <span className={styles.upDesc}>{t.label}</span>
-                      <span className={`${styles.upValue} tnum`}>{formatBRL(t.amountCents)}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </section>
-          </aside>
         </div>
       </main>
     </div>

--- a/src/lib/import/persist.ts
+++ b/src/lib/import/persist.ts
@@ -159,13 +159,21 @@ export async function importWorkbook(filePath: string, filename: string): Promis
     let ruleId: string | null = null
 
     if (deservesRecurrence(e.description)) {
-      // Casa so por label. O label ja carrega o ordinal, entao os dois cartoes
-      // sao regras distintas e a Netflix continua uma serie unica mesmo com o
-      // valor mudando de 44,90 para 59,90.
+      // Casa so por label, normalizado. O label ja carrega o ordinal, entao os
+      // dois cartoes sao regras distintas ('#2' muda a chave) e a Netflix
+      // continua uma serie unica mesmo com o valor mudando de 44,90 para 59,90.
+      // A normalizacao existe porque a planilha alterna a caixa da mesma linha
+      // ('Aparelho Tauana' e 'aparelho tauana'): comparar cru criava uma
+      // segunda regra e dobrava o compromisso na projecao de fluxo de caixa.
       const existing = await db
         .select()
         .from(recurrenceRules)
-        .where(and(eq(recurrenceRules.contextId, ctx.id), eq(recurrenceRules.label, label)))
+        .where(
+          and(
+            eq(recurrenceRules.contextId, ctx.id),
+            sql`lower(trim(${recurrenceRules.label})) = lower(trim(${label}))`,
+          ),
+        )
         .limit(1)
 
       if (existing[0]) {


### PR DESCRIPTION
## O que muda

Dois assuntos, um commit cada.

**1. Remove o painel lateral "A pagar" do dashboard do mes**

O painel duplicava o card "A pagar" do topo e trazia uma coluna com o dia do vencimento que, com todos os lancamentos vencendo no dia 01, repetia o mesmo valor em todas as linhas. Como o `aside` continha apenas esse painel, ele sai junto e o grid volta a coluna unica. O card do topo permanece.

**2. Corrige o casamento de regra de recorrencia no import**

A planilha alterna a caixa da mesma linha ("Aparelho Tauana" e "aparelho tauana"). O upsert comparava o label cru, entao o `select` nao encontrava a regra existente e criava uma segunda, com sua propria serie de ocorrencias futuras: o compromisso aparecia dobrado na projecao de fluxo de caixa.

A comparacao passa a usar `lower(trim())`. Os dois cartoes continuam separados, porque o ordinal faz parte do label e `#2` mantem chave distinta.

## Passivo no banco

Havia 6 labels duplicados. 5 foram fundidos com o script incluido neste PR; `seguro carro` ficou de fora por ser renovacao de apolice, nao duplicata.

| label | mantida | fundida | tx repontadas | previsao removida |
|---|---|---|---|---|
| aparelho tauana | 4 tx | 1 tx | 1 | R$ 2.100,00 |
| cartao joao caixa | 16 tx | 2 tx | 2 | R$ 5.019,98 |
| cartao joao caixa #2 | 14 tx | 1 tx | 1 | R$ 14.434,14 |
| lanche final de semana | 5 tx | 3 tx | 3 | R$ 7.840,00 |
| van zaya | 7 tx | 1 tx | 1 | R$ 2.100,00 |

Total: 8 transacoes repontadas, 70 ocorrencias futuras removidas, cerca de R$ 31.494 de compromisso fantasma fora da projecao.

O sobrevivente e a regra com mais transacoes reais, nao a mais antiga, porque e ela que carrega o historico e o valor atual. Cada fusao roda em transacao: reaponta transacoes, migra ocorrencias realizadas respeitando o unique `(rule, due_date)`, apaga so as previsoes em aberto e herda categoria quando a mantida esta sem.

**A fusao ja foi aplicada no banco**, com backup previo das tabelas afetadas. O script fica no repo para referencia e roda em dry-run por padrao.

## Verificacao

- `npm run typecheck` limpo
- `npm test`: 336 testes, 17 arquivos, todos passando
- Pos-fusao: 0 transacoes orfas, 0 ocorrencias orfas, `seguro carro` intacto com as duas regras ativas

O script de fusao nao tem teste automatizado: a validacao foi o dry-run comparado com o resultado real e as checagens de integridade acima.
