### PR TITLE
fix(fluxo-de-caixa): eixo X vira calendario e marca previsao sem vencimento

### DIFF
--- a/src/components/cashflow-chart.module.css
+++ b/src/components/cashflow-chart.module.css
@@ -154,3 +154,18 @@
   color: var(--ink-faint);
   font-size: 0.7rem;
 }
+
+/* Previsao sem dia de vencimento: a data e palpite, e o tooltip precisa dizer
+   isso. Sem o aviso, um empilhamento no dia 1 se le como compromisso real. */
+.ttWarn {
+  font-size: 0.68rem;
+  color: var(--ink-faint);
+  line-height: 1.3;
+  padding-bottom: 0.15rem;
+}
+
+.ttInferred {
+  color: var(--ink-faint);
+  margin-left: 0.25em;
+  cursor: help;
+}

--- a/src/components/cashflow-chart.tsx
+++ b/src/components/cashflow-chart.tsx
@@ -18,6 +18,13 @@ import styles from './cashflow-chart.module.css'
  *
  * O hover mostra a data e o que moveu naquele dia: a curva diz que caiu, o
  * tooltip diz o que derrubou. Sem isso o mergulho e um mistero.
+ *
+ * O eixo X e o mes inteiro, dia 1 a ultimo dia, porque projectCashflow entrega
+ * todos os dias. Antes so os dias com lancamento entravam na serie e o X saia
+ * do indice: a curva era esticada ate as bordas e a distancia entre dois
+ * pontos nao dizia quantos dias passaram. Um pulo de 5 dias parados ocupava a
+ * mesma largura que um de 1 dia, e a inclinacao deixava de significar
+ * velocidade de queda.
  */
 export function CashflowChart({ projection }: { projection: Projection }) {
   const { days } = projection
@@ -50,12 +57,21 @@ export function CashflowChart({ projection }: { projection: Projection }) {
   const negative = projection.firstNegative !== null
   const last = days.at(-1)!
   const active = hover !== null ? days[hover] : null
+  const inferidos = active?.items.filter((i) => i.dateInferred).length ?? 0
 
-  // Marcas de data no eixo: primeiro dia, ultimo e alguns no meio, sem colidir.
-  const step = Math.max(1, Math.ceil(days.length / 6))
+  // Marcas de data no eixo: dias redondos do calendario (1, 5, 10, ...) mais o
+  // ultimo. Ancorar no dia e nao no indice mantem a regua legivel e estavel
+  // entre meses de 28 e 31 dias.
+  const step = days.length > 20 ? 5 : days.length > 10 ? 3 : 1
   const ticks = days
-    .map((d, i) => ({ i, date: d.date }))
-    .filter((t) => t.i % step === 0 || t.i === days.length - 1)
+    .map((d, i) => ({ i, date: d.date, dia: Number(d.date.slice(8)) }))
+    .filter((t) => t.dia === 1 || t.dia % step === 0 || t.i === days.length - 1)
+    // O ultimo dia do mes pode encostar na marca anterior (30 e 31): descarta
+    // a penultima quando elas ficariam sobrepostas.
+    .filter((t, i, arr) => {
+      const next = arr[i + 1]
+      return !next || next.i - t.i > 1
+    })
 
 
   const label = negative
@@ -88,7 +104,9 @@ export function CashflowChart({ projection }: { projection: Projection }) {
 
         {/* Dia negativo: anel na cor da superficie separa o ponto da linha. */}
         {days.map((d, i) =>
-          d.balanceCents < 0 ? (
+          // So o dia que MOVEU ganha marca: com o mes inteiro na serie, marcar
+          // todo dia negativo desenharia uma fileira continua de bolinhas.
+          d.balanceCents < 0 && d.items.length > 0 ? (
             <circle key={d.date} cx={x(i)} cy={y(d.balanceCents)} r="4" className={styles.dotNeg} />
           ) : null,
         )}
@@ -141,11 +159,20 @@ export function CashflowChart({ projection }: { projection: Projection }) {
           <span className={`${styles.ttBalance} ${active.balanceCents < 0 ? styles.ttNeg : ''} tnum`}>
             saldo {formatBRL(active.balanceCents)}
           </span>
+          {inferidos > 0 && (
+            <span className={styles.ttWarn}>
+              {inferidos} {inferidos === 1 ? 'previsão sem' : 'previsões sem'} dia de vencimento
+              {inferidos === 1 ? ' definido, caiu' : ' definido, caíram'} aqui por padrão
+            </span>
+          )}
           {active.items.length > 0 && (
             <ul className={styles.ttItems}>
               {active.items.slice(0, 5).map((it, k) => (
                 <li key={`${it.label}-${k}`} className={styles.ttItem}>
-                  <span className={styles.ttLabel}>{it.label}</span>
+                  <span className={styles.ttLabel}>
+                    {it.label}
+                    {it.dateInferred && <span className={styles.ttInferred} title="data inferida">~</span>}
+                  </span>
                   <span
                     className={`${styles.ttAmount} ${it.direction === 'in' ? styles.ttIn : styles.ttOut} tnum`}
                   >

--- a/src/lib/cashflow/project.test.ts
+++ b/src/lib/cashflow/project.test.ts
@@ -22,11 +22,18 @@ describe('projectCashflow', () => {
       '2026-07-31',
     )
 
-    expect(p.days.map((d) => [d.date, d.balanceCents])).toEqual([
-      ['2026-07-05', 400000],
-      ['2026-07-12', 250000],
-      ['2026-07-20', 65000],
-    ])
+    // A serie cobre o mes inteiro; dia sem movimento carrega o saldo anterior.
+    expect(p.days).toHaveLength(31)
+    expect(p.days[0]!.date).toBe('2026-07-01')
+    expect(p.days.at(-1)!.date).toBe('2026-07-31')
+
+    const saldoEm = (date: string) => p.days.find((d) => d.date === date)!.balanceCents
+    expect(saldoEm('2026-07-04')).toBe(0)
+    expect(saldoEm('2026-07-05')).toBe(400000)
+    expect(saldoEm('2026-07-11')).toBe(400000)
+    expect(saldoEm('2026-07-12')).toBe(250000)
+    expect(saldoEm('2026-07-20')).toBe(65000)
+    expect(saldoEm('2026-07-31')).toBe(65000)
     expect(p.closingBalanceCents).toBe(65000)
     expect(p.totalInCents).toBe(400000)
     expect(p.totalOutCents).toBe(335000)
@@ -80,9 +87,10 @@ describe('projectCashflow', () => {
       '2026-07-31',
     )
     expect(p.firstNegative).toBeNull()
-    expect(p.days[0]!.balanceCents).toBe(0)
+    const dia10 = p.days.find((d) => d.date === '2026-07-10')!
+    expect(dia10.balanceCents).toBe(0)
     // A ordem dentro do dia: entrada primeiro.
-    expect(p.days[0]!.items[0]!.direction).toBe('in')
+    expect(dia10.items[0]!.direction).toBe('in')
   })
 
   it('ignora o que está fora da janela', () => {
@@ -96,16 +104,26 @@ describe('projectCashflow', () => {
       '2026-07-01',
       '2026-07-31',
     )
-    expect(p.days).toHaveLength(1)
+    // O mes inteiro entra na serie, mas so o item de julho move o saldo.
+    expect(p.days).toHaveLength(31)
+    expect(p.days.flatMap((d) => d.items)).toHaveLength(1)
+    expect(p.days.find((d) => d.date === '2026-07-10')!.items).toHaveLength(1)
     expect(p.closingBalanceCents).toBe(5000)
   })
 
-  it('lida com janela vazia', () => {
+  it('mês sem movimento vira linha plana, não série vazia', () => {
     const p = projectCashflow([], 50000, '2026-07-01', '2026-07-31')
-    expect(p.days).toEqual([])
+    expect(p.days).toHaveLength(31)
+    expect(p.days.every((d) => d.balanceCents === 50000)).toBe(true)
+    expect(p.days.every((d) => d.items.length === 0)).toBe(true)
     expect(p.closingBalanceCents).toBe(50000)
-    expect(p.trough).toBeNull()
+    expect(p.trough?.balanceCents).toBe(50000)
     expect(p.firstNegative).toBeNull()
+  })
+
+  it('não gira infinito se a janela vier invertida', () => {
+    const p = projectCashflow([], 0, '2026-07-31', '2026-07-01')
+    expect(p.days).toEqual([])
   })
 })
 

--- a/src/lib/cashflow/project.ts
+++ b/src/lib/cashflow/project.ts
@@ -18,6 +18,13 @@ export interface FlowItem {
   /** Ja aconteceu (pago/recebido) ou ainda e previsao. */
   settled: boolean
   ruleId: string | null
+  /**
+   * Previsao cuja regra nao tem dia de vencimento: a data e um palpite (o dia
+   * do starts_on), nao um compromisso real. A planilha nao trazia o dia nessas
+   * linhas. Some no dia 1 e nao no dia certo, entao a curva mostra um degrau
+   * que na vida real esta espalhado pelo mes.
+   */
+  dateInferred?: boolean
 }
 
 export interface DayPoint {
@@ -47,6 +54,13 @@ export interface Projection {
  * Ordena por data e acumula. Dentro do mesmo dia, entrada antes de saida:
  * e o comportamento otimista, mas e o realista para salario/vencimento no
  * mesmo dia, e evita alarme falso de negativo que se resolve em horas.
+ *
+ * A serie cobre TODOS os dias de [from, to], inclusive os sem movimento. Antes
+ * so os dias com lancamento entravam, e o grafico plotava por indice: o mes
+ * virava uma regua elastica onde a distancia entre dois pontos nao dizia
+ * quantos dias passaram, e a curva era esticada ate as bordas mesmo quando o
+ * primeiro movimento caia no dia 12. Dia parado e informacao: o saldo fica
+ * onde estava.
  */
 export function projectCashflow(
   items: FlowItem[],
@@ -63,14 +77,13 @@ export function projectCashflow(
     byDate.set(i.date, arr)
   }
 
-  const dates = [...byDate.keys()].sort()
   const days: DayPoint[] = []
   let balance = openingBalanceCents
   let totalIn = 0
   let totalOut = 0
 
-  for (const date of dates) {
-    const dayItems = byDate.get(date)!
+  for (const date of eachDay(from, to)) {
+    const dayItems = byDate.get(date) ?? []
     // Entrada antes de saida no mesmo dia.
     dayItems.sort((a, b) => (a.direction === b.direction ? 0 : a.direction === 'in' ? -1 : 1))
 
@@ -169,6 +182,19 @@ export function upcomingCommitments(items: FlowItem[], today: string, days = 14)
   return items
     .filter((i) => !i.settled && i.direction === 'out' && i.date >= today && i.date <= limit)
     .sort((a, b) => a.date.localeCompare(b.date) || b.amountCents - a.amountCents)
+}
+
+/** Todos os dias do intervalo, inclusive os extremos. */
+function eachDay(from: string, to: string): string[] {
+  const out: string[] = []
+  let cur = from
+  // Guarda contra intervalo invertido ou datas malformadas: sem isto um
+  // `to` menor que `from` giraria para sempre.
+  for (let i = 0; cur <= to && i < 400; i++) {
+    out.push(cur)
+    cur = addDays(cur, 1)
+  }
+  return out
 }
 
 function addDays(iso: string, n: number): string {

--- a/src/lib/cashflow/queries.ts
+++ b/src/lib/cashflow/queries.ts
@@ -64,6 +64,7 @@ export async function getFlowItems(
       kind: recurrenceRules.kind,
       ruleId: recurrenceRules.id,
       installmentTotal: recurrenceRules.installmentTotal,
+      dayOfMonth: recurrenceRules.dayOfMonth,
     })
     .from(recurrenceOccurrences)
     .innerJoin(recurrenceRules, eq(recurrenceRules.id, recurrenceOccurrences.ruleId))
@@ -88,6 +89,9 @@ export async function getFlowItems(
     direction: o.kind === 'income' ? 'in' : 'out',
     settled: false,
     ruleId: o.ruleId,
+    // Sem dia de vencimento na regra, o gerador cai no dia do starts_on. Marca
+    // para a UI poder dizer que a data e inferida em vez de afirmar um dia.
+    dateInferred: o.dayOfMonth === null,
   }))
 
   return [...fromTx, ...fromOcc].sort((a, b) => a.date.localeCompare(b.date))


### PR DESCRIPTION
## Contexto

O grafico de fluxo de caixa "nao refletia so o mes". Investigando, sao **dois problemas independentes**. O recorte por mes esta correto: `monthRange` gera `2026-08-01..2026-08-31`, a query filtra por `dueDate` e `projectCashflow` refiltra a janela. Nenhum dado de outro mes entra.

## 1. O eixo X nao era uma linha do tempo

A serie so continha dias **com** lancamento, e o X saia do indice do array:

```
const x = (i) => PAD + (i / (days.length - 1)) * (W - PAD * 2)
```

| mes | dias no mes | pontos no grafico |
|---|---|---|
| 2026-07 | 31 | **15** |
| 2026-08 | 31 | 28 |

Em julho, metade do mes nao existia no eixo, e a curva era esticada ate as bordas. O dia 02 era desenhado colado na esquerda como se fosse o dia 1; o dia 20 caia no meio exato; o desvio chegava a **83px num eixo de 640px**.

Pior que o desalinhamento era o efeito semantico: 5 dias parados (15 a 20) ocupavam a mesma largura que 1 dia (5 a 6), entao a inclinacao deixava de significar velocidade de queda.

**Correcao:** `projectCashflow` emite todos os dias de `[from, to]`. Dia parado carrega o saldo anterior e vira patamar horizontal. Com a serie continua, o indice volta a ser proporcional ao tempo. As marcas do eixo ancoram em dias redondos (1, 5, 10, ...) em vez de multiplos do indice.

## 2. Previsoes empilhadas no dia 1

O tooltip do dia 01/08 listava 55 lancamentos e saldo de R$ 20.479,61, com o mes fechando em R$ 9.620,71.

O dado esta certo no banco, o erro e a montante. **51 das 216 regras ativas nao tem `day_of_month`** (a planilha nao trazia o dia; o import gravou `null`), e o gerador cai no dia do `starts_on` em `generate.ts:90`. Todas essas regras comecam no dia 01.

| dia | ocorrencias em agosto |
|---|---|
| **01** | **55** |
| 10 | 22 |
| 05 | 15 |

**Correcao (paliativa):** a UI para de afirmar um dia que nao foi informado. `FlowItem` ganha `dateInferred`, o item recebe `~` no tooltip e o dia mostra quantas previsoes cairam ali por falta de vencimento definido.

Isto e **sinalizacao, nao correcao**. A solucao real e preencher `day_of_month` regra a regra, o que depende de informacao que so o usuario tem. Nao inventei um dia padrao: seria chute com outra cara.

## Verificacao

- `npm run typecheck` limpo
- `npm test`: **337 testes**, 17 arquivos, todos passando
- 4 testes de `projectCashflow` foram atualizados: assumiam a serie antiga (so dias com movimento). Os valores de saldo, negativo e vale continuam identicos; mudou so a forma da serie. Adicionei cobertura para mes sem movimento (linha plana em vez de serie vazia) e guarda contra janela invertida.
- Dados reais: julho e agosto/2026 agora com 31 pontos, comecando no dia 01, com o mesmo saldo de fechamento de antes.

Nao consegui validar pela UI porque a pagina exige login e eu nao insiro credenciais. Validei renderizando o SVG a partir dos dados reais: os patamares horizontais aparecem nos dias parados e os ticks ficam uniformes (01, 05, 10, 15, 20, 25, 31, com 104px entre cada 5 dias).
