### PR TITLE
fix(recorrencia): encerra regra que parou de acontecer

### DIFF
--- a/scripts/retire-stale-rules.ts
+++ b/scripts/retire-stale-rules.ts
@@ -1,0 +1,96 @@
+import 'dotenv/config'
+import { sql } from 'drizzle-orm'
+import { db } from '@/db'
+import { STALE_MONTHS } from '@/lib/recurrence/retire'
+
+/**
+ * Encerra regras de recorrencia que pararam de acontecer.
+ *
+ * O import promove a regra por heuristica sobre a descricao (deservesRecurrence),
+ * entao um trabalho avulso de 2022 virou assinatura mensal sem fim: cadence
+ * 'monthly' e ends_on null. O gerador cumpre o combinado e produz ocorrencia
+ * todo mes, para sempre. O resultado e um mes futuro cheio de previsao nascida
+ * de evento que aconteceu uma vez, anos atras.
+ *
+ * A regra morre quando para de acontecer: sem lancamento real ha STALE_MONTHS,
+ * ends_on recebe a data do ultimo lancamento e a geracao para ali. Ocorrencias
+ * futuras ainda em aberto (sem transacao, sem skip) somem junto, porque foram
+ * criadas por uma regra que nao valia mais.
+ *
+ * NAO apaga transacao nem regra: ends_on preserva o historico e mantem a regra
+ * disponivel caso o lancamento volte a acontecer.
+ *
+ * Roda em dry-run por padrao. Para gravar: --apply
+ */
+
+const apply = process.argv.includes('--apply')
+const brl = (c: number | string) => `R$ ${(Number(c) / 100).toFixed(2)}`
+
+async function main() {
+  const res = await db.execute(sql`
+    with u as (
+      select rr.id, rr.label, rr.kind, rr.amount_cents, rr.starts_on,
+             (select max(t.due_date) from transactions t where t.rule_id = rr.id) as ultima,
+             (select count(*) from transactions t where t.rule_id = rr.id) as n_tx
+      from recurrence_rules rr
+      where rr.active = true and rr.ends_on is null
+    )
+    select *,
+      (select count(*) from recurrence_occurrences o
+        where o.rule_id = u.id and o.due_date > current_date
+          and o.transaction_id is null and o.skipped_at is null) as occ_futuras,
+      (select coalesce(sum(o.expected_cents), 0) from recurrence_occurrences o
+        where o.rule_id = u.id and o.due_date > current_date
+          and o.transaction_id is null and o.skipped_at is null) as occ_cents
+    from u
+    where ultima is null
+       or ultima < (current_date - make_interval(months => ${STALE_MONTHS}))
+    order by ultima nulls first, label
+  `)
+  const rows = ((res as any).rows ?? res) as any[]
+
+  console.log(apply ? '=== APLICANDO ===' : '=== DRY-RUN (nada sera gravado) ===')
+  console.log(`criterio: sem lancamento real ha mais de ${STALE_MONTHS} meses\n`)
+
+  let occTotal = 0
+  let centsIn = 0
+  let centsOut = 0
+
+  for (const r of rows) {
+    occTotal += Number(r.occ_futuras)
+    if (r.kind === 'income') centsIn += Number(r.occ_cents)
+    else centsOut += Number(r.occ_cents)
+    console.log(
+      `${r.label} | ultima=${r.ultima ?? 'NUNCA'} | ${r.n_tx} tx | ` +
+        `${r.occ_futuras} previsao(oes) futura(s) ${brl(r.occ_cents)}`,
+    )
+  }
+
+  console.log(`\n--- Resumo ---`)
+  console.log(`regras encerradas: ${rows.length}`)
+  console.log(`previsoes futuras removidas: ${occTotal}`)
+  console.log(`receita fantasma: ${brl(centsIn)}`)
+  console.log(`despesa fantasma: ${brl(centsOut)}`)
+
+  if (!apply) {
+    console.log(`\nNada foi gravado. Rode com --apply para efetivar.`)
+    return
+  }
+
+  for (const r of rows) {
+    await db.transaction(async (tx) => {
+      // Sem lancamento nenhum, a regra nunca valeu: encerra no proprio inicio.
+      const end = r.ultima ?? r.starts_on
+      await tx.execute(sql`update recurrence_rules set ends_on = ${end}, active = false where id = ${r.id}`)
+      await tx.execute(sql`
+        delete from recurrence_occurrences
+        where rule_id = ${r.id} and due_date > ${end}
+          and transaction_id is null and skipped_at is null
+      `)
+    })
+  }
+  console.log(`\n${rows.length} regras encerradas.`)
+}
+
+await main()
+process.exit(0)

--- a/src/lib/import/persist.ts
+++ b/src/lib/import/persist.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { db } from '@/db'
 import {
   transactions,
@@ -12,6 +12,7 @@ import {
 } from '@/db/schema'
 import { parseWorkbook, type ParsedEntry, type ParsedSheet } from './xlsx'
 import { deservesRecurrence } from '../classify'
+import { selectStaleRules } from '../recurrence/retire'
 
 /**
  * Persiste uma planilha no banco.
@@ -27,6 +28,8 @@ export interface ImportResult {
   inserted: number
   skipped: number
   rulesCreated: number
+  /** Regras que pararam de acontecer e foram encerradas neste import. */
+  rulesRetired: number
   warnings: number
 }
 
@@ -226,12 +229,65 @@ export async function importWorkbook(filePath: string, filename: string): Promis
     inserted++
   }
 
+  // O import cria regra com folga (quase tudo merece uma), entao ele tambem
+  // precisa fechar a conta: sem isso, todo lancamento avulso vira previsao
+  // eterna e o mes futuro enche de coisa que aconteceu uma vez, anos atras.
+  const rulesRetired = await retireStaleRules(ctx.id, periodEndISO(periodLabel))
+
   return {
     filename,
     period: periodLabel,
     inserted,
     skipped,
     rulesCreated,
+    rulesRetired,
     warnings: parsed.warnings.length,
   }
+}
+
+/** Ultimo dia do periodo importado: o "hoje" da decisao de encerramento. */
+function periodEndISO(periodLabel: string): string {
+  const [m, y] = periodLabel.split('/').map(Number) as [number, number]
+  const last = new Date(Date.UTC(y, m, 0)).getUTCDate()
+  return `${y}-${String(m).padStart(2, '0')}-${last}`
+}
+
+/**
+ * Encerra regras que pararam de aparecer e limpa as previsoes que elas ja
+ * tinham gerado adiante. Nao apaga regra nem transacao: ends_on preserva o
+ * historico e deixa a regra pronta caso o lancamento volte.
+ */
+async function retireStaleRules(contextId: string, today: string): Promise<number> {
+  const rows = await db
+    .select({
+      id: recurrenceRules.id,
+      startsOn: recurrenceRules.startsOn,
+      lastSeen: sql<string | null>`(
+        select max(t.due_date)::text from ${transactions} t where t.rule_id = ${recurrenceRules.id}
+      )`,
+    })
+    .from(recurrenceRules)
+    .where(and(eq(recurrenceRules.contextId, contextId), isNull(recurrenceRules.endsOn)))
+
+  const stale = selectStaleRules(rows, today)
+
+  for (const r of stale) {
+    await db
+      .update(recurrenceRules)
+      .set({ endsOn: r.endsOn, active: false })
+      .where(eq(recurrenceRules.id, r.id))
+
+    await db
+      .delete(recurrenceOccurrences)
+      .where(
+        and(
+          eq(recurrenceOccurrences.ruleId, r.id),
+          sql`${recurrenceOccurrences.dueDate} > ${r.endsOn}`,
+          isNull(recurrenceOccurrences.transactionId),
+          isNull(recurrenceOccurrences.skippedAt),
+        ),
+      )
+  }
+
+  return stale.length
 }

--- a/src/lib/recurrence/retire.test.ts
+++ b/src/lib/recurrence/retire.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { selectStaleRules, monthsBefore } from './retire'
+
+const rule = (over: Partial<Parameters<typeof selectStaleRules>[0][number]> & { id: string }) => ({
+  startsOn: '2022-01-01',
+  lastSeen: null,
+  ...over,
+})
+
+describe('selectStaleRules', () => {
+  it('encerra regra que parou de acontecer, na data do ultimo lancamento', () => {
+    const out = selectStaleRules([rule({ id: 'a', lastSeen: '2022-06-01' })], '2026-08-22')
+    expect(out).toEqual([{ id: 'a', endsOn: '2022-06-01' }])
+  })
+
+  it('mantem regra que ainda acontece', () => {
+    const out = selectStaleRules([rule({ id: 'a', lastSeen: '2026-07-10' })], '2026-08-22')
+    expect(out).toEqual([])
+  })
+
+  /** Anual fica 11 meses parado sem estar morto: o corte de 12 meses o protege. */
+  it('não mata lançamento anual', () => {
+    const out = selectStaleRules([rule({ id: 'iptu', lastSeen: '2025-10-01' })], '2026-08-22')
+    expect(out).toEqual([])
+  })
+
+  it('regra sem lançamento nenhum encerra no próprio início', () => {
+    const out = selectStaleRules([rule({ id: 'a', startsOn: '2022-06-01' })], '2026-08-22')
+    expect(out).toEqual([{ id: 'a', endsOn: '2022-06-01' }])
+  })
+
+  it('é exatamente o limite, não aproximado', () => {
+    // 12 meses antes de 2026-08-22 é 2025-08-22.
+    expect(selectStaleRules([rule({ id: 'a', lastSeen: '2025-08-22' })], '2026-08-22')).toEqual([])
+    expect(selectStaleRules([rule({ id: 'a', lastSeen: '2025-08-21' })], '2026-08-22')).toEqual([
+      { id: 'a', endsOn: '2025-08-21' },
+    ])
+  })
+
+  it('respeita um corte customizado', () => {
+    const out = selectStaleRules([rule({ id: 'a', lastSeen: '2026-01-10' })], '2026-08-22', 6)
+    expect(out).toEqual([{ id: 'a', endsOn: '2026-01-10' }])
+  })
+})
+
+describe('monthsBefore', () => {
+  it('volta meses dentro do mesmo ano', () => {
+    expect(monthsBefore('2026-08-22', 3)).toBe('2026-05-22')
+  })
+
+  it('atravessa a virada do ano', () => {
+    expect(monthsBefore('2026-02-10', 12)).toBe('2025-02-10')
+    expect(monthsBefore('2026-01-15', 1)).toBe('2025-12-15')
+  })
+
+  it('clampa dia em mês curto', () => {
+    expect(monthsBefore('2026-03-31', 1)).toBe('2026-02-28')
+  })
+})

--- a/src/lib/recurrence/retire.ts
+++ b/src/lib/recurrence/retire.ts
@@ -1,0 +1,67 @@
+/**
+ * Quando uma regra de recorrencia deixou de valer.
+ *
+ * O import promove quase todo lancamento a regra (deservesRecurrence e
+ * !oneOff), porque a fatura do cartao precisa existir no futuro projetado
+ * mesmo variando de valor. O custo dessa escolha e que um trabalho avulso
+ * tambem vira regra mensal sem fim, e o gerador cumpre o combinado: produz
+ * ocorrencia todo mes, para sempre.
+ *
+ * O sintoma aparece longe da causa. Um mes futuro fica cheio de previsao
+ * nascida de evento unico de anos atras, e o saldo projetado passa a
+ * descrever um mes que nao vai acontecer.
+ *
+ * O criterio aqui e observacao, nao heuristica de texto: a regra vale
+ * enquanto o lancamento continua aparecendo. Parou de aparecer ha
+ * STALE_MONTHS, encerra em ends_on e a geracao para ali.
+ */
+
+/** Meses sem lancamento real ate a regra ser considerada morta. */
+export const STALE_MONTHS = 12
+
+export interface RuleActivity {
+  id: string
+  startsOn: string
+  /** Data do ultimo lancamento real, ou null se a regra nunca teve nenhum. */
+  lastSeen: string | null
+}
+
+export interface Retirement {
+  id: string
+  /** Data em que a regra passa a valer como encerrada. */
+  endsOn: string
+}
+
+/**
+ * Quais regras encerrar, dado o "hoje" de referencia.
+ *
+ * Recebe today explicito para ser deterministico: a decisao depende da data,
+ * e um teste que le o relogio muda de resultado conforme o dia em que roda.
+ */
+export function selectStaleRules(
+  rules: RuleActivity[],
+  today: string,
+  staleMonths = STALE_MONTHS,
+): Retirement[] {
+  const cutoff = monthsBefore(today, staleMonths)
+
+  return rules
+    .filter((r) => (r.lastSeen ?? r.startsOn) < cutoff)
+    .map((r) => ({
+      // Sem lancamento nenhum a regra nunca valeu: encerra no proprio inicio,
+      // senao ela sobrevive ate o cutoff produzindo previsao que nunca existiu.
+      id: r.id,
+      endsOn: r.lastSeen ?? r.startsOn,
+    }))
+}
+
+/** Subtrai meses de uma data ISO, clampando dia em mes curto (31 -> 28). */
+export function monthsBefore(iso: string, months: number): string {
+  const [y, m, d] = iso.split('-').map(Number) as [number, number, number]
+  const total = y * 12 + (m - 1) - months
+  const ny = Math.floor(total / 12)
+  const nm = (total % 12) + 1
+  const last = new Date(Date.UTC(ny, nm, 0)).getUTCDate()
+  const nd = Math.min(d, last)
+  return `${ny}-${String(nm).padStart(2, '0')}-${String(nd).padStart(2, '0')}`
+}


### PR DESCRIPTION
## O problema

O fluxo de caixa da aba mes vinha cheio de lancamento que nao pertence ao mes.

Investigando: **nao e vazamento de filtro**. Os 227 itens de agosto/2026 tinham todos `due_date` em agosto, e `getFlowItems` recorta corretamente por `from`/`to`. Eram previsoes **de** agosto, geradas a partir de eventos unicos de anos atras.

| regra | ultimo lancamento real | nº de lancamentos |
|---|---|---|
| Correçao bug Mapp | **2022-06-01** | 1 |
| Trabalho Site Matias | **2022-06-01** | 1 |
| Venda conta cs | **2022-06-01** | 1 |
| Acerto Laika | **2023-01-01** | 1 |

"Correçao bug Mapp" aconteceu uma vez, em junho de 2022. Virou `recurrence_rule` com `cadence: monthly` e `ends_on: null`, e o gerador cumpriu o combinado: uma ocorrencia por mes, para sempre.

**Escala:** 147 das 216 regras ativas sem lancamento real ha mais de um ano; 86 com exatamente um lancamento na vida.

## A causa

`deservesRecurrence` retorna `!oneOff`, ou seja, quase tudo vira regra. Isso e deliberado e esta documentado em `classify.ts`: a fatura do cartao precisa existir no futuro projetado mesmo variando de valor.

O que faltava era o outro lado da conta: **nada encerrava a regra quando o lancamento parava de aparecer**.

## A correcao

Criterio por observacao, nao por heuristica de texto: sem lancamento real ha **12 meses**, `ends_on` recebe a data do ultimo lancamento e a geracao para ali (`generate.ts` ja respeita `ends_on`).

Escolhi 12 e nao 6 meses para nao matar lancamento anual, que fica 11 meses parado sem estar morto. Ha um teste cobrindo exatamente esse caso.

Nao apaga regra nem transacao: `ends_on` preserva o historico e deixa a regra pronta caso o lancamento volte. Some so a previsao futura em aberto.

O import passa a fechar essa conta ao final (`retireStaleRules`), senao o proximo arquivo recria o passivo.

## Efeito

| | antes | depois |
|---|---|---|
| itens em agosto/2026 | 227 | **81** |
| lancamentos no dia 01 | 55 | **1** |
| previsoes futuras removidas | | 1921 |
| receita fantasma | | R$ 709.048,68 |
| despesa fantasma | | R$ 657.556,57 |

## Verificacao

- `npm run typecheck` limpo
- `npm test`: **346 testes** (9 novos em `retire.test.ts`), 18 arquivos, todos passando
- A logica de decisao esta em `lib/recurrence/retire.ts`, pura e com `today` explicito, para ser deterministica em teste
- Pos-aplicacao: 0 previsoes alem do `ends_on`, e as **1491 transacoes** do banco intactas

O passivo ja foi aplicado no banco com backup previo. O script fica no repo e roda em dry-run por padrao.

Nao validei pela UI porque a pagina exige login e eu nao insiro credenciais; validei pelos dados e por SVG renderizado a partir deles.
